### PR TITLE
fix: allow resetApiState after store release

### DIFF
--- a/.changeset/fresh-seals-flash.md
+++ b/.changeset/fresh-seals-flash.md
@@ -1,0 +1,5 @@
+---
+'ngrx-rtk-query': patch
+---
+
+Allow `resetApiState` to be dispatched after an API store has been released while still preserving the unbound-store error for other actions.

--- a/packages/ngrx-rtk-query/core/src/create-api.ts
+++ b/packages/ngrx-rtk-query/core/src/create-api.ts
@@ -1,4 +1,4 @@
-import { type Action } from '@reduxjs/toolkit';
+import { type Action, type UnknownAction } from '@reduxjs/toolkit';
 import {
   type Api,
   type CoreModule,
@@ -26,9 +26,12 @@ type ApiBinding = ApiBindingMetadata & {
   store: AngularHooksModuleOptions;
 };
 
+type RuntimeApi = Api<any, Record<string, any>, string, string, AngularHooksModule | CoreModule>;
+
 export const createApi: CreateApi<typeof coreModuleName | typeof angularHooksModuleName> = (options) => {
   let resolvedReducerPath = options.reducerPath ?? 'api';
   let activeBinding: ApiBinding | undefined;
+  let isResetApiStateAction = (_action: unknown): _action is UnknownAction => false;
   const getUnboundStoreError = () => {
     return new Error(
       `Provide the API (${resolvedReducerPath}) is necessary to use the queries. Did you forget to provide the queries api?`,
@@ -43,6 +46,10 @@ export const createApi: CreateApi<typeof coreModuleName | typeof angularHooksMod
   };
   const dispatch = (action: unknown): unknown => {
     if (!activeBinding) {
+      if (isResetApiStateAction(action)) {
+        return action;
+      }
+
       throw getUnboundStoreError();
     }
 
@@ -69,8 +76,8 @@ export const createApi: CreateApi<typeof coreModuleName | typeof angularHooksMod
     }),
   );
   const api = createApi(options);
+  const runtimeApi = api as unknown as RuntimeApi;
   resolvedReducerPath = (api as unknown as { reducerPath: string }).reducerPath;
-  const runtimeApi = api as unknown as Api<any, Record<string, any>, string, string, AngularHooksModule | CoreModule>;
 
   const createBinding = (setupFn: () => AngularHooksModuleOptions, bindingMetadata: ApiBindingMetadata): ApiBinding => {
     const store = setupFn();
@@ -110,6 +117,7 @@ export const createApi: CreateApi<typeof coreModuleName | typeof angularHooksMod
 
     const binding = createBinding(setupFn, nextBindingMetadata);
     activeBinding = binding;
+    isResetApiStateAction = (action: unknown): action is UnknownAction => runtimeApi.util.resetApiState.match(action);
 
     return () => {
       if (activeBinding?.bindingKey === nextBindingMetadata.bindingKey) {

--- a/packages/ngrx-rtk-query/tests/create-api.spec.ts
+++ b/packages/ngrx-rtk-query/tests/create-api.spec.ts
@@ -53,6 +53,14 @@ describe('createApi', () => {
     vi.useRealTimers();
   });
 
+  test('throws when resetting the api before any host store is bound', () => {
+    const postsApi = createPostsApi('unboundApi') as InitializedTestApi;
+
+    expect(() => postsApi.dispatch(postsApi.util.resetApiState())).toThrow(
+      /Provide the API \(unboundApi\) is necessary to use the queries/,
+    );
+  });
+
   test('unbinds the api when the host store is released', () => {
     const postsApi = createPostsApi('releasedApi') as InitializedTestApi;
     const { releaseApiStore } = initBoundTestApiStore(postsApi);
@@ -61,12 +69,14 @@ describe('createApi', () => {
 
     releaseApiStore();
 
-    expect(() => postsApi.dispatch(postsApi.util.resetApiState())).toThrow(
+    expect(() => postsApi.dispatch(postsApi.util.resetApiState())).not.toThrow();
+
+    expect(() => postsApi.dispatch({ type: 'releasedApi/customAction' })).toThrow(
       /Provide the API \(releasedApi\) is necessary to use the queries/,
     );
   });
 
-  test('ignores delayed middleware next work after reset and release', async () => {
+  test('allows resetting the api after the host store is released even with pending middleware work', async () => {
     vi.useFakeTimers();
 
     const postsApi = createPostsApi('releasedTimerApi') as InitializedTestApi;
@@ -78,7 +88,9 @@ describe('createApi', () => {
 
     await vi.advanceTimersByTimeAsync(500);
 
-    expect(() => postsApi.dispatch(postsApi.util.resetApiState())).toThrow(
+    expect(() => postsApi.dispatch(postsApi.util.resetApiState())).not.toThrow();
+
+    expect(() => postsApi.dispatch({ type: 'releasedTimerApi/customAction' })).toThrow(
       /Provide the API \(releasedTimerApi\) is necessary to use the queries/,
     );
   });


### PR DESCRIPTION
## Summary
- allow `resetApiState` to be dispatched after an API store has been released
- keep throwing the existing unbound-store error for non-reset actions after release
- add a patch changeset and regression coverage for pre-bind and post-release behavior

## Verification
- `pnpm nx test ngrx-rtk-query --testFile=create-api.spec.ts`