### PR TITLE
fix: allow resetApiState before store init

### DIFF
--- a/.changeset/real-seas-talk.md
+++ b/.changeset/real-seas-talk.md
@@ -1,0 +1,5 @@
+---
+'ngrx-rtk-query': patch
+---
+
+Allow `resetApiState` to be dispatched even before an API store has been bound so it behaves as a safe no-op cleanup step.

--- a/packages/ngrx-rtk-query/core/src/create-api.ts
+++ b/packages/ngrx-rtk-query/core/src/create-api.ts
@@ -78,6 +78,7 @@ export const createApi: CreateApi<typeof coreModuleName | typeof angularHooksMod
   const api = createApi(options);
   const runtimeApi = api as unknown as RuntimeApi;
   resolvedReducerPath = (api as unknown as { reducerPath: string }).reducerPath;
+  isResetApiStateAction = (action: unknown): action is UnknownAction => runtimeApi.util.resetApiState.match(action);
 
   const createBinding = (setupFn: () => AngularHooksModuleOptions, bindingMetadata: ApiBindingMetadata): ApiBinding => {
     const store = setupFn();
@@ -117,7 +118,6 @@ export const createApi: CreateApi<typeof coreModuleName | typeof angularHooksMod
 
     const binding = createBinding(setupFn, nextBindingMetadata);
     activeBinding = binding;
-    isResetApiStateAction = (action: unknown): action is UnknownAction => runtimeApi.util.resetApiState.match(action);
 
     return () => {
       if (activeBinding?.bindingKey === nextBindingMetadata.bindingKey) {

--- a/packages/ngrx-rtk-query/tests/create-api.spec.ts
+++ b/packages/ngrx-rtk-query/tests/create-api.spec.ts
@@ -53,12 +53,10 @@ describe('createApi', () => {
     vi.useRealTimers();
   });
 
-  test('throws when resetting the api before any host store is bound', () => {
+  test('allows resetting the api before any host store is bound', () => {
     const postsApi = createPostsApi('unboundApi') as InitializedTestApi;
 
-    expect(() => postsApi.dispatch(postsApi.util.resetApiState())).toThrow(
-      /Provide the API \(unboundApi\) is necessary to use the queries/,
-    );
+    expect(() => postsApi.dispatch(postsApi.util.resetApiState())).not.toThrow();
   });
 
   test('unbinds the api when the host store is released', () => {


### PR DESCRIPTION
## Summary
- allow `resetApiState` to be dispatched before any API host store has been bound
- keep the unbound-store error for other actions without a bound host store
- add a patch changeset and update regression coverage for the before-bind case

## Verification
- `pnpm nx test ngrx-rtk-query --testFile=create-api.spec.ts`