### PR TITLE
fix: support reactive hook options

### DIFF
--- a/.changeset/reactive-query-hooks.md
+++ b/.changeset/reactive-query-hooks.md
@@ -1,0 +1,5 @@
+---
+"ngrx-rtk-query": patch
+---
+
+Support reactive mutation options and callable query result signal keys.

--- a/packages/ngrx-rtk-query/README.md
+++ b/packages/ngrx-rtk-query/README.md
@@ -379,6 +379,12 @@ Like in the original library, a mutation is a object (not array) with each of it
 // Use mutation hook
 addPost = useAddPostMutation();
 
+// Mutation options can be static, a Signal, or a function.
+// This is useful for route-scoped fixedCacheKey values.
+updatePost = useUpdatePostMutation(() => ({
+  fixedCacheKey: `updatePost:${this.postId()}`,
+}));
+
 // Mutation trigger
 this.addPost({ params });
 

--- a/packages/ngrx-rtk-query/core/src/build-hooks.ts
+++ b/packages/ngrx-rtk-query/core/src/build-hooks.ts
@@ -38,6 +38,7 @@ import {
   type UseInfiniteQueryStateOptions,
   type UseInfiniteQuerySubscription,
   type UseInfiniteQuerySubscriptionOptions,
+  type UseLazyQueryOptions,
   type UseLazyQuerySubscription,
   type UseMutation,
   type UseQueryState,
@@ -48,7 +49,7 @@ import {
   isInfiniteQueryDefinition,
 } from './types';
 import { useStableQueryArgs } from './useSerializedStableValue';
-import { shallowEqual, signalProxy, toDeepSignal, toLazySignal } from './utils';
+import { mergeSignalProxy, shallowEqual, signalProxy, toDeepSignal, toLazySignal } from './utils';
 
 /**
  * Wrapper around `defaultQueryStateSelector` to be used in `useQuery`.
@@ -428,6 +429,10 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
   }
 
   function buildQueryHooks(endpointName: string): QueryHooks<any> {
+    type LazyQueryOptionsInput<R extends Record<string, any>> =
+      | UseLazyQueryOptions<any, R>
+      | (() => UseLazyQueryOptions<any, R>);
+
     const useQuerySubscription: UseQuerySubscription<any> = (arg: any, options = {}) => {
       const [promiseRef] = useQuerySubscriptionCommonImpl<QueryActionCreatorResult<any>>(endpointName, arg, options);
 
@@ -441,7 +446,13 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       };
     };
 
-    const useLazyQuerySubscription: UseLazyQuerySubscription<any> = (options = {}) => {
+    const readLazyQueryOptions = <R extends Record<string, any>>(options: LazyQueryOptionsInput<R>) =>
+      typeof options === 'function' ? toLazySignal(options, { initialValue: {} }) : () => options;
+
+    const useLazyQuerySubscriptionImpl = <R extends Record<string, any>>(
+      options: LazyQueryOptionsInput<R> = {},
+      lazyOptions = readLazyQueryOptions(options),
+    ) => {
       const { initiate } = api.endpoints[endpointName] as ApiEndpointQuery<
         QueryDefinition<any, any, any, any, any>,
         Definitions
@@ -456,7 +467,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
             refetchOnFocus,
             pollingInterval = 0,
             skipPollingIfUnfocused = false,
-          } = typeof options === 'function' ? options() : options;
+          } = lazyOptions();
           return { refetchOnReconnect, refetchOnFocus, pollingInterval, skipPollingIfUnfocused };
         },
         { equal: shallowEqual },
@@ -516,6 +527,8 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
 
       return [trigger, lastArg, { reset }] as const;
     };
+    const useLazyQuerySubscription: UseLazyQuerySubscription<any> = (options = {}) =>
+      useLazyQuerySubscriptionImpl(options);
 
     const useQueryState: UseQueryState<any> = buildUseQueryState(endpointName, queryStatePreSelector);
 
@@ -523,18 +536,18 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       useQueryState,
       useQuerySubscription,
       useLazyQuerySubscription,
-      useLazyQuery(options) {
-        const [trigger, arg, { reset }] = useLazyQuerySubscription(options);
+      useLazyQuery(options = {}) {
+        const lazyOptions = readLazyQueryOptions(options);
+        const [trigger, arg, { reset }] = useLazyQuerySubscriptionImpl(options, lazyOptions);
         const subscriptionOptions = computed(() => ({
-          ...options,
+          ...lazyOptions(),
           skip: arg() === UNINITIALIZED_VALUE,
         }));
         const queryStateResults = useQueryState(arg, subscriptionOptions);
         const signalsMap = signalProxy(queryStateResults);
         Object.assign(trigger, { lastArg: arg, reset });
-        Object.assign(trigger, signalsMap);
 
-        return trigger as any;
+        return mergeSignalProxy(trigger, signalsMap, ['lastArg', 'reset']) as any;
       },
       useQuery(arg, options) {
         const querySubscriptionResults = useQuerySubscription(arg, options);
@@ -648,8 +661,17 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       Definitions
     >;
 
-    const useMutation: UseMutation<any> = ({ selectFromResult, fixedCacheKey } = {}) => {
+    const useMutation: UseMutation<any> = (options = {}) => {
+      const readMutationOptions = () => (typeof options === 'function' ? options() : options);
+      const lazyOptions = typeof options === 'function' ? toLazySignal(options, { initialValue: {} }) : () => options;
       const promiseRef = signal<MutationActionCreatorResult<any> | undefined>(undefined);
+      const mutationOptions = computed(
+        () => {
+          const { selectFromResult, fixedCacheKey } = lazyOptions();
+          return { selectFromResult, fixedCacheKey };
+        },
+        { equal: shallowEqual },
+      );
 
       effect((onCleanup) => {
         const currentPromise = promiseRef();
@@ -661,6 +683,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       });
 
       const triggerMutation = (arg: Parameters<typeof initiate>['0']) => {
+        const { fixedCacheKey } = readMutationOptions();
         const promise = dispatch(initiate(arg, { fixedCacheKey }));
         promiseRef.set(promise);
         return promise;
@@ -681,18 +704,25 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       };
 
       const requestId = computed(() => promiseRef()?.requestId);
-      const selectDefaultResult = (requestId?: string) => fixedSelect({ fixedCacheKey, requestId });
-      const mutationSelector = (requestId?: string): Selector<RootState<Definitions, any, any>, any> =>
+      const selectDefaultResult = (requestId?: string, fixedCacheKey?: string) =>
+        fixedSelect({ fixedCacheKey, requestId });
+      const mutationSelector = (
+        requestId?: string,
+        { selectFromResult, fixedCacheKey } = mutationOptions(),
+      ): Selector<RootState<Definitions, any, any>, any> =>
         selectFromResult
-          ? createSelector(selectDefaultResult(requestId), selectFromResult)
-          : selectDefaultResult(requestId);
+          ? createSelector(selectDefaultResult(requestId, fixedCacheKey), selectFromResult)
+          : selectDefaultResult(requestId, fixedCacheKey);
 
       const currentState = computed(() => useSelector(mutationSelector(requestId()), { equal: shallowEqual }));
-      const originalArgs = computed(() => (fixedCacheKey == null ? promiseRef()?.arg.originalArgs : undefined));
+      const originalArgs = computed(() =>
+        mutationOptions().fixedCacheKey == null ? promiseRef()?.arg.originalArgs : undefined,
+      );
       const reset = () => {
         if (promiseRef()) {
           promiseRef.set(undefined);
         }
+        const { fixedCacheKey } = readMutationOptions();
         if (fixedCacheKey) {
           dispatch(
             api.internalActions.removeMutationResult({
@@ -707,9 +737,8 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       const signalsMap = signalProxy(finalState);
       Object.assign(triggerMutation, { originalArgs });
       Object.assign(triggerMutation, { reset });
-      Object.assign(triggerMutation, signalsMap);
 
-      return triggerMutation as any;
+      return mergeSignalProxy(triggerMutation, signalsMap, ['originalArgs', 'reset']) as any;
     };
 
     return { useMutation };

--- a/packages/ngrx-rtk-query/core/src/types/hooks-types.ts
+++ b/packages/ngrx-rtk-query/core/src/types/hooks-types.ts
@@ -1078,7 +1078,10 @@ export type TypedUseMutationResult<
 export type UseMutation<D extends MutationDefinition<any, any, any, any>> = <
   R extends Record<string, any> = MutationResultSelectorResult<D>,
 >(
-  options?: UseMutationStateOptions<D, R>,
+  options?:
+    | UseMutationStateOptions<D, R>
+    | Signal<UseMutationStateOptions<D, R>>
+    | (() => UseMutationStateOptions<D, R>),
 ) => MutationTrigger<D> & UseMutationStateResult<D, R>;
 
 export type TypedUseMutation<ResultType, QueryArg, BaseQuery extends BaseQueryFn> = UseMutation<

--- a/packages/ngrx-rtk-query/core/src/utils/signal-proxy.ts
+++ b/packages/ngrx-rtk-query/core/src/utils/signal-proxy.ts
@@ -47,21 +47,56 @@ export function signalProxy<T extends Record<string | symbol, any>>(signal: Sign
       return (target[prop] = computed(() => signal()[prop]));
     },
     has(_, prop) {
-      return !!untracked(signal)[prop];
+      return Reflect.ownKeys(untracked(signal)).includes(prop);
     },
     ownKeys() {
       return Reflect.ownKeys(untracked(signal));
     },
-    getOwnPropertyDescriptor() {
-      return {
-        enumerable: true,
-        configurable: true,
-      };
+    getOwnPropertyDescriptor(_, prop) {
+      return Reflect.ownKeys(untracked(signal)).includes(prop)
+        ? {
+            enumerable: true,
+            configurable: true,
+          }
+        : undefined;
     },
   });
 }
 
+export function mergeSignalProxy<TTarget extends object, TSignals extends Record<string | symbol, unknown>>(
+  target: TTarget,
+  signalsMap: TSignals,
+  targetProps: readonly (string | symbol)[] = [],
+): TTarget & TSignals {
+  const targetPropsSet = new Set<string | symbol>(targetProps);
+  const isNonConfigurableTargetProp = (prop: string | symbol) => {
+    const targetDescriptor = Reflect.getOwnPropertyDescriptor(target, prop);
+    return targetDescriptor ? !targetDescriptor.configurable : false;
+  };
+  const hasSignalProp = (prop: string | symbol) =>
+    !targetPropsSet.has(prop) && !isNonConfigurableTargetProp(prop) && Reflect.has(signalsMap, prop);
+
+  return new Proxy(target, {
+    get(target, prop, receiver) {
+      if (hasSignalProp(prop)) return Reflect.get(signalsMap, prop, receiver);
+      return Reflect.get(target, prop, receiver);
+    },
+    getOwnPropertyDescriptor(target, prop) {
+      const targetDescriptor = Reflect.getOwnPropertyDescriptor(target, prop);
+      if (targetDescriptor && !targetDescriptor.configurable) return targetDescriptor;
+      if (hasSignalProp(prop)) return Reflect.getOwnPropertyDescriptor(signalsMap, prop);
+      return targetDescriptor;
+    },
+    has(target, prop) {
+      return prop in target || hasSignalProp(prop);
+    },
+    ownKeys(target) {
+      return Array.from(new Set([...Reflect.ownKeys(target), ...Reflect.ownKeys(signalsMap)]));
+    },
+  }) as TTarget & TSignals;
+}
+
 export function toDeepSignal<T extends Record<string | symbol, any>>(signal: Signal<T>): DeepSignal<T> {
   const deepSignal = signalProxy(signal);
-  return Object.assign(signal, deepSignal);
+  return mergeSignalProxy(signal, deepSignal);
 }

--- a/packages/ngrx-rtk-query/tests/helpers/create-posts-api.ts
+++ b/packages/ngrx-rtk-query/tests/helpers/create-posts-api.ts
@@ -15,6 +15,11 @@ export const createPostsApi = (reducerPath: string) =>
           data: [{ id: 1, name: `${reducerPath}-post` }],
         }),
       }),
+      getPost: build.query<Post, number>({
+        queryFn: async (id) => ({
+          data: { id, name: `${reducerPath}-post-${id}` },
+        }),
+      }),
       addPost: build.mutation<Post, { name: string }>({
         queryFn: async ({ name }) => ({
           data: { id: 1, name },

--- a/packages/ngrx-rtk-query/tests/lazy-query-hooks.spec.ts
+++ b/packages/ngrx-rtk-query/tests/lazy-query-hooks.spec.ts
@@ -1,0 +1,325 @@
+import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
+import { render, screen, waitFor } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test } from 'vitest';
+
+import { provideNoopStoreApi } from 'ngrx-rtk-query/noop-store';
+
+import { createPostsApi } from './helpers/create-posts-api';
+
+describe('lazy query hooks', () => {
+  test('starts without data until manually triggered', async () => {
+    const postsApi = createPostsApi('lazyQueryInitialStateApi');
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <p>{{ postsQuery.data()?.[0]?.name ?? (postsQuery.isUninitialized() ? 'empty' : 'loaded') }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly postsQuery = postsApi.useLazyGetPostsQuery();
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(screen.getByText('empty')).toBeInTheDocument();
+  });
+
+  test('loads data from a manual static trigger and exposes lastArg', async () => {
+    const postsApi = createPostsApi('lazyQueryStaticTriggerApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="postQuery(1)">load post</button>
+        <p>{{ postQuery.data()?.name ?? 'empty' }}</p>
+        <p>last arg {{ postQuery.lastArg() }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly postQuery = postsApi.useLazyGetPostQuery();
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(screen.getByText('empty')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'load post' }));
+
+    expect(await screen.findByText('lazyQueryStaticTriggerApi-post-1')).toBeInTheDocument();
+    expect(screen.getByText('last arg 1')).toBeInTheDocument();
+  });
+
+  test('uses the current signal value when manually triggered', async () => {
+    const postsApi = createPostsApi('lazyQuerySignalTriggerApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="activeId.set(2)">next</button>
+        <button (click)="loadCurrent()">load current</button>
+        <p>{{ postQuery.data()?.name ?? 'empty' }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly activeId = signal(1);
+      readonly postQuery = postsApi.useLazyGetPostQuery();
+
+      loadCurrent() {
+        this.postQuery(this.activeId());
+      }
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    await user.click(screen.getByRole('button', { name: 'next' }));
+    await user.click(screen.getByRole('button', { name: 'load current' }));
+
+    expect(await screen.findByText('lazyQuerySignalTriggerApi-post-2')).toBeInTheDocument();
+  });
+
+  test('uses required input values when manually triggered', async () => {
+    const postsApi = createPostsApi('lazyQueryRequiredInputTriggerApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="loadCurrent()">load current</button>
+        <p>{{ postQuery.data()?.name ?? 'empty' }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly activeId = input.required<number>();
+      readonly postQuery = postsApi.useLazyGetPostQuery();
+
+      loadCurrent() {
+        this.postQuery(this.activeId());
+      }
+    }
+
+    const { rerender } = await render(HostComponent, {
+      componentInputs: { activeId: 1 },
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    await user.click(screen.getByRole('button', { name: 'load current' }));
+
+    expect(await screen.findByText('lazyQueryRequiredInputTriggerApi-post-1')).toBeInTheDocument();
+
+    await rerender({ componentInputs: { activeId: 2 } });
+    await user.click(screen.getByRole('button', { name: 'load current' }));
+
+    expect(await screen.findByText('lazyQueryRequiredInputTriggerApi-post-2')).toBeInTheDocument();
+  });
+
+  test('exposes selected lazy query result keys that collide with trigger function properties', async () => {
+    const postsApi = createPostsApi('lazyQuerySelectedFunctionPropertyApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="postsQuery()">load posts</button>
+        <p>{{ postsQuery.name() }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly postsQuery = postsApi.useLazyGetPostsQuery({
+        selectFromResult: ({ data }) => ({
+          name: data?.[0]?.name ?? 'empty',
+        }),
+      });
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(screen.getByText('empty')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'load posts' }));
+
+    expect(await screen.findByText('lazyQuerySelectedFunctionPropertyApi-post')).toBeInTheDocument();
+  });
+
+  test('tracks lazy query options from a signal', async () => {
+    const postsApi = createPostsApi('lazyQuerySignalOptionsApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="postsQuery()">load posts</button>
+        <button (click)="showName.set(false)">hide name</button>
+        <p>{{ postsQuery.selectedName() }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly showName = signal(true);
+      readonly queryOptions = computed(() => ({
+        selectFromResult: ({ data }: { data?: { name: string }[] }) => ({
+          selectedName: this.showName() ? (data?.[0]?.name ?? 'empty') : 'hidden',
+        }),
+      }));
+      readonly postsQuery = postsApi.useLazyGetPostsQuery(this.queryOptions);
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    await user.click(screen.getByRole('button', { name: 'load posts' }));
+
+    expect(await screen.findByText('lazyQuerySignalOptionsApi-post')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'hide name' }));
+
+    expect(await screen.findByText('hidden')).toBeInTheDocument();
+  });
+
+  test('tracks lazy query options from a function derived from component state', async () => {
+    const postsApi = createPostsApi('lazyQueryFunctionOptionsApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="postsQuery()">load posts</button>
+        <button (click)="showName.set(false)">hide name</button>
+        <p>{{ postsQuery.selectedName() }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly showName = signal(true);
+      readonly postsQuery = postsApi.useLazyGetPostsQuery(() => ({
+        selectFromResult: ({ data }) => ({
+          selectedName: this.showName() ? (data?.[0]?.name ?? 'empty') : 'hidden',
+        }),
+      }));
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    await user.click(screen.getByRole('button', { name: 'load posts' }));
+
+    expect(await screen.findByText('lazyQueryFunctionOptionsApi-post')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'hide name' }));
+
+    expect(await screen.findByText('hidden')).toBeInTheDocument();
+  });
+
+  test('supports function-based lazy query options derived from required inputs', async () => {
+    const postsApi = createPostsApi('lazyQueryRequiredInputOptionsApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="postQuery(1)">load post</button>
+        <p>{{ postQuery.selectedName() }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly label = input.required<string>();
+      readonly postQuery = postsApi.useLazyGetPostQuery(() => ({
+        selectFromResult: ({ data }) => ({
+          selectedName: data ? `${this.label()}:${data.name}` : 'empty',
+        }),
+      }));
+    }
+
+    await render(HostComponent, {
+      componentInputs: { label: 'selected' },
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(screen.getByText('empty')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'load post' }));
+
+    expect(await screen.findByText('selected:lazyQueryRequiredInputOptionsApi-post-1')).toBeInTheDocument();
+  });
+
+  test('reset clears the visible lazy query result', async () => {
+    const postsApi = createPostsApi('lazyQueryResetApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="postsQuery()">load posts</button>
+        <button (click)="postsQuery.reset()">reset</button>
+        <p>{{ postsQuery.data()?.[0]?.name ?? 'empty' }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly postsQuery = postsApi.useLazyGetPostsQuery();
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    await user.click(screen.getByRole('button', { name: 'load posts' }));
+
+    expect(await screen.findByText('lazyQueryResetApi-post')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'reset' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('empty')).toBeInTheDocument();
+    });
+  });
+
+  test('can prefer a cached value when triggering a cached lazy query', async () => {
+    const postsApi = createPostsApi('lazyQueryPreferCacheValueApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="postQuery(1)">load post</button>
+        <button (click)="postQuery(1, { preferCacheValue: true })">load cached post</button>
+        <p>{{ postQuery.data()?.name ?? 'empty' }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly postQuery = postsApi.useLazyGetPostQuery();
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    await user.click(screen.getByRole('button', { name: 'load post' }));
+
+    expect(await screen.findByText('lazyQueryPreferCacheValueApi-post-1')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'load cached post' }));
+
+    expect(await screen.findByText('lazyQueryPreferCacheValueApi-post-1')).toBeInTheDocument();
+  });
+});

--- a/packages/ngrx-rtk-query/tests/mutation-hooks.spec.ts
+++ b/packages/ngrx-rtk-query/tests/mutation-hooks.spec.ts
@@ -1,0 +1,463 @@
+import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
+import { render, screen, waitFor } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test } from 'vitest';
+
+import { createApi, fakeBaseQuery } from 'ngrx-rtk-query/core';
+import { provideNoopStoreApi } from 'ngrx-rtk-query/noop-store';
+
+import { createPostsApi } from './helpers/create-posts-api';
+
+type MutationOptionsMode = 'function' | 'signal';
+
+async function renderReactiveMutationHook(reducerPath: string, optionsMode: MutationOptionsMode = 'function') {
+  const postsApi = createPostsApi(reducerPath);
+  const user = userEvent.setup();
+
+  @Component({
+    standalone: true,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    template: `
+      <button (click)="saveCurrent()">save current</button>
+      <button (click)="activeId.set(2)">next</button>
+      <button (click)="activeId.set(1)">previous</button>
+      <button (click)="addPost.reset()">reset current</button>
+      <p data-testid="mutation-name">{{ addPost.data()?.name ?? 'empty' }}</p>
+    `,
+  })
+  class HostComponent {
+    readonly activeId = signal(1);
+    readonly mutationOptions = computed(() => ({ fixedCacheKey: `save:${this.activeId()}` }));
+    readonly addPost =
+      optionsMode === 'signal'
+        ? postsApi.useAddPostMutation(this.mutationOptions)
+        : postsApi.useAddPostMutation(() => ({ fixedCacheKey: `save:${this.activeId()}` }));
+
+    saveCurrent() {
+      this.addPost({ name: `Saved for ${this.activeId()}` });
+    }
+  }
+
+  await render(HostComponent, {
+    providers: [provideNoopStoreApi(postsApi)],
+  });
+
+  return { user };
+}
+
+describe('mutation hooks', () => {
+  test('tracks mutation state through function-based reactive fixedCacheKey options', async () => {
+    const { user } = await renderReactiveMutationHook('reactiveMutationFunctionOptionsApi');
+
+    expect(screen.getByTestId('mutation-name')).toHaveTextContent('empty');
+
+    await user.click(screen.getByRole('button', { name: 'save current' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved for 1');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'next' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('empty');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'previous' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved for 1');
+    });
+  });
+
+  test('uses current function-based fixedCacheKey options when triggering a mutation', async () => {
+    const { user } = await renderReactiveMutationHook('reactiveMutationTriggerOptionsApi');
+
+    await user.click(screen.getByRole('button', { name: 'next' }));
+    await user.click(screen.getByRole('button', { name: 'save current' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved for 2');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'previous' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('empty');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'next' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved for 2');
+    });
+  });
+
+  test('uses function-based fixedCacheKey options for synchronous mutation triggers', async () => {
+    const postsApi = createPostsApi('reactiveMutationSyncTriggerOptionsApi');
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="activeId.set(2)">next</button>
+        <button (click)="activeId.set(1)">previous</button>
+        <p data-testid="mutation-name">{{ addPost.data()?.name ?? 'empty' }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly activeId = signal(1);
+      readonly addPost = postsApi.useAddPostMutation(() => ({ fixedCacheKey: `save:${this.activeId()}` }));
+
+      constructor() {
+        this.addPost({ name: 'Saved for 1' });
+      }
+    }
+
+    const user = userEvent.setup();
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved for 1');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'next' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('empty');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'previous' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved for 1');
+    });
+  });
+
+  test('uses computed fixedCacheKey options for synchronous mutation triggers', async () => {
+    const postsApi = createPostsApi('reactiveMutationSyncSignalOptionsApi');
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="activeId.set(2)">next</button>
+        <button (click)="activeId.set(1)">previous</button>
+        <p data-testid="mutation-name">{{ addPost.data()?.name ?? 'empty' }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly activeId = signal(1);
+      readonly mutationOptions = computed(() => ({ fixedCacheKey: `save:${this.activeId()}` }));
+      readonly addPost = postsApi.useAddPostMutation(this.mutationOptions);
+
+      constructor() {
+        this.addPost({ name: 'Saved for 1' });
+      }
+    }
+
+    const user = userEvent.setup();
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved for 1');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'next' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('empty');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'previous' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved for 1');
+    });
+  });
+
+  test('accepts computed mutation options signals', async () => {
+    const { user } = await renderReactiveMutationHook('reactiveMutationSignalOptionsApi', 'signal');
+
+    await user.click(screen.getByRole('button', { name: 'save current' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved for 1');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'next' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('empty');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'previous' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved for 1');
+    });
+  });
+
+  test('supports function-based mutation options derived from required inputs', async () => {
+    const postsApi = createPostsApi('reactiveMutationRequiredInputOptionsApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="saveCurrent()">save current</button>
+        <p data-testid="mutation-name">{{ addPost.data()?.name ?? 'empty' }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly activeId = input.required<number>();
+      readonly addPost = postsApi.useAddPostMutation(() => ({ fixedCacheKey: `save:${this.activeId()}` }));
+
+      saveCurrent() {
+        this.addPost({ name: `Saved for ${this.activeId()}` });
+      }
+    }
+
+    const { rerender } = await render(HostComponent, {
+      componentInputs: { activeId: 1 },
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    await user.click(screen.getByRole('button', { name: 'save current' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved for 1');
+    });
+
+    await rerender({ componentInputs: { activeId: 2 } });
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('empty');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'save current' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved for 2');
+    });
+
+    await rerender({ componentInputs: { activeId: 1 } });
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved for 1');
+    });
+  });
+
+  test('tracks error state through reactive fixedCacheKey options', async () => {
+    const postsApi = createApi({
+      reducerPath: 'reactiveMutationErrorOptionsApi',
+      baseQuery: fakeBaseQuery(),
+      endpoints: (build) => ({
+        savePost: build.mutation<{ id: number; name: string }, { name: string; shouldFail?: boolean }>({
+          queryFn: async ({ name, shouldFail }) =>
+            shouldFail
+              ? {
+                  error: {
+                    status: 400,
+                    data: name,
+                  },
+                }
+              : {
+                  data: { id: 1, name },
+                },
+        }),
+      }),
+    });
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="failCurrent()">fail current</button>
+        <button (click)="activeId.set(2)">next</button>
+        <button (click)="activeId.set(1)">previous</button>
+        <p data-testid="mutation-state">
+          {{ savePost.isError() ? 'error' : (savePost.data()?.name ?? 'empty') }}
+        </p>
+      `,
+    })
+    class HostComponent {
+      readonly activeId = signal(1);
+      readonly savePost = postsApi.useSavePostMutation(() => ({ fixedCacheKey: `save:${this.activeId()}` }));
+
+      failCurrent() {
+        this.savePost({ name: `Failed for ${this.activeId()}`, shouldFail: true });
+      }
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(screen.getByTestId('mutation-state')).toHaveTextContent('empty');
+
+    await user.click(screen.getByRole('button', { name: 'fail current' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-state')).toHaveTextContent('error');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'next' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-state')).toHaveTextContent('empty');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'previous' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-state')).toHaveTextContent('error');
+    });
+  });
+
+  test('tracks reactive selectFromResult mutation options', async () => {
+    const postsApi = createPostsApi('reactiveMutationSelectFromResultApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="saveCurrent()">save current</button>
+        <button (click)="showName.set(false)">hide name</button>
+        <button (click)="showName.set(true)">show name</button>
+        <p data-testid="selected-name">{{ addPost.selectedName() }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly showName = signal(true);
+      readonly addPost = postsApi.useAddPostMutation(() => ({
+        fixedCacheKey: 'select-from-result',
+        selectFromResult: ({ data }) => ({
+          selectedName: this.showName() ? (data?.name ?? 'empty') : 'hidden',
+        }),
+      }));
+
+      saveCurrent() {
+        this.addPost({ name: 'Saved' });
+      }
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(screen.getByTestId('selected-name')).toHaveTextContent('empty');
+
+    await user.click(screen.getByRole('button', { name: 'save current' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-name')).toHaveTextContent('Saved');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'hide name' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-name')).toHaveTextContent('hidden');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'show name' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-name')).toHaveTextContent('Saved');
+    });
+  });
+
+  test('exposes selected mutation result keys that collide with function properties', async () => {
+    const postsApi = createPostsApi('mutationSelectedFunctionPropertyApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="saveCurrent()">save current</button>
+        <p data-testid="selected-name">{{ addPost.name() }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly addPost = postsApi.useAddPostMutation({
+        fixedCacheKey: 'selected-name',
+        selectFromResult: ({ data }) => ({
+          name: data?.name ?? 'empty',
+        }),
+      });
+
+      saveCurrent() {
+        this.addPost({ name: 'Saved' });
+      }
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(screen.getByTestId('selected-name')).toHaveTextContent('empty');
+
+    await user.click(screen.getByRole('button', { name: 'save current' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-name')).toHaveTextContent('Saved');
+    });
+  });
+
+  test('exposes and resets originalArgs for mutations without fixedCacheKey', async () => {
+    const postsApi = createPostsApi('mutationOriginalArgsApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="saveCurrent()">save current</button>
+        <button (click)="addPost.reset()">reset current</button>
+        <p data-testid="mutation-name">{{ addPost.data()?.name ?? 'empty' }}</p>
+        <p data-testid="original-name">{{ addPost.originalArgs()?.name ?? 'empty' }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly addPost = postsApi.useAddPostMutation();
+
+      saveCurrent() {
+        this.addPost({ name: 'Saved' });
+      }
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(screen.getByTestId('mutation-name')).toHaveTextContent('empty');
+    expect(screen.getByTestId('original-name')).toHaveTextContent('empty');
+
+    await user.click(screen.getByRole('button', { name: 'save current' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved');
+      expect(screen.getByTestId('original-name')).toHaveTextContent('Saved');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'reset current' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('empty');
+      expect(screen.getByTestId('original-name')).toHaveTextContent('empty');
+    });
+  });
+
+  test('does not reset previous fixedCacheKey buckets when reactive options change', async () => {
+    const { user } = await renderReactiveMutationHook('reactiveMutationNoAutoResetApi');
+
+    await user.click(screen.getByRole('button', { name: 'save current' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved for 1');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'next' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('empty');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'save current' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved for 2');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'reset current' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('empty');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'previous' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-name')).toHaveTextContent('Saved for 1');
+    });
+  });
+});

--- a/packages/ngrx-rtk-query/tests/query-hooks.spec.ts
+++ b/packages/ngrx-rtk-query/tests/query-hooks.spec.ts
@@ -1,0 +1,229 @@
+import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
+import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test } from 'vitest';
+
+import { skipToken } from 'ngrx-rtk-query/core';
+import { provideNoopStoreApi } from 'ngrx-rtk-query/noop-store';
+
+import { createPostsApi } from './helpers/create-posts-api';
+
+describe('query hooks', () => {
+  test('loads a query from a static arg', async () => {
+    const postsApi = createPostsApi('queryStaticArgApi');
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <p>{{ postQuery.data()?.name ?? 'empty' }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly postQuery = postsApi.useGetPostQuery(1);
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(await screen.findByText('queryStaticArgApi-post-1')).toBeInTheDocument();
+  });
+
+  test('tracks a query arg from a signal', async () => {
+    const postsApi = createPostsApi('querySignalArgApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="activeId.set(2)">next</button>
+        <p>{{ postQuery.data()?.name ?? 'empty' }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly activeId = signal(1);
+      readonly postQuery = postsApi.useGetPostQuery(this.activeId);
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(await screen.findByText('querySignalArgApi-post-1')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'next' }));
+
+    expect(await screen.findByText('querySignalArgApi-post-2')).toBeInTheDocument();
+  });
+
+  test('tracks a query arg from a function', async () => {
+    const postsApi = createPostsApi('queryFunctionArgApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="activeId.set(2)">next</button>
+        <p>{{ postQuery.data()?.name ?? 'empty' }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly activeId = signal(1);
+      readonly postQuery = postsApi.useGetPostQuery(() => this.activeId());
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(await screen.findByText('queryFunctionArgApi-post-1')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'next' }));
+
+    expect(await screen.findByText('queryFunctionArgApi-post-2')).toBeInTheDocument();
+  });
+
+  test('tracks a query arg from required inputs', async () => {
+    const postsApi = createPostsApi('queryRequiredInputArgApi');
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <p>{{ postQuery.data()?.name ?? 'empty' }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly activeId = input.required<number>();
+      readonly postQuery = postsApi.useGetPostQuery(() => this.activeId());
+    }
+
+    const { rerender } = await render(HostComponent, {
+      componentInputs: { activeId: 1 },
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(await screen.findByText('queryRequiredInputArgApi-post-1')).toBeInTheDocument();
+
+    await rerender({ componentInputs: { activeId: 2 } });
+
+    expect(await screen.findByText('queryRequiredInputArgApi-post-2')).toBeInTheDocument();
+  });
+
+  test('skips a query through skipToken until the arg is available', async () => {
+    const postsApi = createPostsApi('querySkipTokenArgApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="enabled.set(true)">enable</button>
+        <p>{{ postQuery.data()?.name ?? (postQuery.isUninitialized() ? 'skipped' : 'empty') }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly enabled = signal(false);
+      readonly postQuery = postsApi.useGetPostQuery(() => (this.enabled() ? 1 : skipToken));
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(screen.getByText('skipped')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'enable' }));
+
+    expect(await screen.findByText('querySkipTokenArgApi-post-1')).toBeInTheDocument();
+  });
+
+  test('exposes selected query result keys that collide with signal function properties', async () => {
+    const postsApi = createPostsApi('querySelectedFunctionPropertyApi');
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <p>{{ postQuery.name() }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly postQuery = postsApi.useGetPostsQuery(undefined, {
+        selectFromResult: ({ data }) => ({
+          name: data?.[0]?.name ?? 'empty',
+        }),
+      });
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(await screen.findByText('querySelectedFunctionPropertyApi-post')).toBeInTheDocument();
+  });
+
+  test('tracks query options from a signal', async () => {
+    const postsApi = createPostsApi('querySignalOptionsApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="skipped.set(false)">load</button>
+        <p>{{ postQuery.data()?.name ?? (postQuery.isUninitialized() ? 'skipped' : 'empty') }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly skipped = signal(true);
+      readonly queryOptions = computed(() => ({ skip: this.skipped() }));
+      readonly postQuery = postsApi.useGetPostQuery(1, this.queryOptions);
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(screen.getByText('skipped')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'load' }));
+
+    expect(await screen.findByText('querySignalOptionsApi-post-1')).toBeInTheDocument();
+  });
+
+  test('tracks query options from a function derived from component state', async () => {
+    const postsApi = createPostsApi('queryFunctionOptionsApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="showName.set(false)">hide name</button>
+        <p>{{ postQuery.selectedName() }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly showName = signal(true);
+      readonly postQuery = postsApi.useGetPostQuery(1, () => ({
+        selectFromResult: ({ data }) => ({
+          selectedName: this.showName() ? (data?.name ?? 'empty') : 'hidden',
+        }),
+      }));
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(await screen.findByText('queryFunctionOptionsApi-post-1')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'hide name' }));
+
+    expect(await screen.findByText('hidden')).toBeInTheDocument();
+  });
+});

--- a/packages/ngrx-rtk-query/tests/signal-proxy.spec.ts
+++ b/packages/ngrx-rtk-query/tests/signal-proxy.spec.ts
@@ -1,0 +1,26 @@
+import { signal } from '@angular/core';
+import { describe, expect, test } from 'vitest';
+
+import { mergeSignalProxy, signalProxy } from '../core/src/utils';
+
+describe('signal proxy utilities', () => {
+  test('does not shadow non-configurable function properties', () => {
+    const target = function trigger() {
+      return 'target';
+    };
+    Object.defineProperty(target, 'locked', {
+      configurable: false,
+      value: null,
+      writable: false,
+    });
+    const source = signal({
+      locked: 'selected locked',
+      name: 'selected name',
+    });
+
+    const proxy = mergeSignalProxy(target, signalProxy(source));
+
+    expect(Reflect.get(proxy, 'name')()).toBe('selected name');
+    expect(Reflect.get(proxy, 'locked')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Support reactive mutation options from static objects, signals, and functions.
- Preserve callable query/mutation result signal keys such as `name` without violating proxy invariants.
- Normalize lazy query options across subscription and state paths.
- Add behavioral coverage for query, lazy query, mutation, and signal proxy regressions.
- Add a patch changeset for `ngrx-rtk-query`.

## Validation
- `pnpm exec nx test ngrx-rtk-query --skip-nx-cache`
- `pnpm exec nx build ngrx-rtk-query --skip-nx-cache`
- `pnpm exec nx lint ngrx-rtk-query --skip-nx-cache`
- `git diff --check`

Note: local git still prints the existing fsmonitor IPC warning during diff/status commands, but checks completed successfully.