### PR TITLE
docs: document selectFromResult signal contract

### DIFF
--- a/packages/ngrx-rtk-query/README.md
+++ b/packages/ngrx-rtk-query/README.md
@@ -215,10 +215,23 @@ postQuery = useGetPostsQuery(
 );
 
 // Use query with static params or options (can be mixed)
-postQuery = useGetPostsQuery(2, {
-  selectFromResult: ({ data: post, isLoading }) => ({ post, isLoading }),
+postQuery = useGetPostsQuery(undefined, {
+  selectFromResult: ({ data }) => ({
+    post: data?.find((post) => post.id === 2),
+  }),
+});
+
+// Return base query fields explicitly when you also need them as signals
+postQuery = useGetPostsQuery(undefined, {
+  selectFromResult: ({ data, isFetching, isLoading }) => ({
+    post: data?.find((post) => post.id === 2),
+    isFetching,
+    isLoading,
+  }),
 });
 ```
+
+`selectFromResult` follows RTK Query semantics: it replaces the query state result with the object you return. The returned keys are still exposed as fine-grained signals, so `postQuery.post()` works, and `postQuery.isLoading()` works when `isLoading` is returned from `selectFromResult`. Fields such as `data`, `error`, or `isLoading` are not added automatically.
 
 A good use case is to work with router inputs.
 
@@ -263,9 +276,22 @@ options = signal(...);
 postQuery = useLazyGetPostsQuery(options);
 // Use query with static options
 postQuery = useLazyGetPostsQuery({
-  selectFromResult: ({ data: post, isLoading }) => ({ post, isLoading }),
+  selectFromResult: ({ data }) => ({
+    post: data?.find((post) => post.id === 2),
+  }),
+});
+
+// Return base query fields explicitly when you also need them as signals
+postQuery = useLazyGetPostsQuery({
+  selectFromResult: ({ data, isFetching, isLoading }) => ({
+    post: data?.find((post) => post.id === 2),
+    isFetching,
+    isLoading,
+  }),
 });
 ```
+
+`selectFromResult` follows the same contract for lazy queries: only the returned result keys are exposed as query-state signals. The trigger function still keeps lazy-query methods such as `lastArg()` and `reset()`.
 
 Use when data needs to be loaded on demand
 

--- a/packages/ngrx-rtk-query/core/src/types/hooks-types.ts
+++ b/packages/ngrx-rtk-query/core/src/types/hooks-types.ts
@@ -447,7 +447,9 @@ export type UseQueryStateOptions<D extends QueryDefinition<any, any, any, any>, 
    * item has changed.
    * If the selected item is one element in a larger collection, it will disregard changes to elements in
    * the same collection.
-   * Note that this should always return an object (not a primitive), as RTKQ adds fields to the return value.
+   * This replaces the query state result with the object you return. Return base query fields explicitly
+   * when you need them in the hook result.
+   * Note that this should always return an object (not a primitive).
    *
    * @example
    * ```ts

--- a/packages/ngrx-rtk-query/tests/helpers/create-posts-api.ts
+++ b/packages/ngrx-rtk-query/tests/helpers/create-posts-api.ts
@@ -27,3 +27,28 @@ export const createPostsApi = (reducerPath: string) =>
       }),
     }),
   });
+
+export const createDeferredPostsApi = (reducerPath: string) => {
+  const deferred: { resolvePosts?: (posts: Post[]) => void } = {};
+  const posts = new Promise<Post[]>((resolve) => {
+    deferred.resolvePosts = resolve;
+  });
+  const resolvePosts = (nextPosts: Post[]) => {
+    if (!deferred.resolvePosts) throw new Error('Deferred posts resolver was not initialized.');
+    deferred.resolvePosts(nextPosts);
+  };
+
+  const postsApi = createApi({
+    reducerPath,
+    baseQuery: fakeBaseQuery(),
+    endpoints: (build) => ({
+      getPosts: build.query<Post[], void>({
+        queryFn: async () => ({
+          data: await posts,
+        }),
+      }),
+    }),
+  });
+
+  return { postsApi, resolvePosts };
+};

--- a/packages/ngrx-rtk-query/tests/lazy-query-hooks.spec.ts
+++ b/packages/ngrx-rtk-query/tests/lazy-query-hooks.spec.ts
@@ -5,7 +5,7 @@ import { describe, expect, test } from 'vitest';
 
 import { provideNoopStoreApi } from 'ngrx-rtk-query/noop-store';
 
-import { createPostsApi } from './helpers/create-posts-api';
+import { createDeferredPostsApi, createPostsApi } from './helpers/create-posts-api';
 
 describe('lazy query hooks', () => {
   test('starts without data until manually triggered', async () => {
@@ -155,6 +155,86 @@ describe('lazy query hooks', () => {
     await user.click(screen.getByRole('button', { name: 'load posts' }));
 
     expect(await screen.findByText('lazyQuerySelectedFunctionPropertyApi-post')).toBeInTheDocument();
+  });
+
+  test('keeps the lazy query result properties limited to the selected query result', async () => {
+    const postsApi = createPostsApi('lazyQuerySelectedResultContractApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="postsQuery()">load posts</button>
+        <p>{{ postsQuery.selectedName() }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly postsQuery = postsApi.useLazyGetPostsQuery({
+        selectFromResult: ({ data }) => ({
+          selectedName: data?.[0]?.name ?? 'empty',
+        }),
+      });
+    }
+
+    const { fixture } = await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(screen.getByText('empty')).toBeInTheDocument();
+    expect(Reflect.has(fixture.componentInstance.postsQuery, 'selectedName')).toBe(true);
+    expect(Reflect.has(fixture.componentInstance.postsQuery, 'isLoading')).toBe(false);
+    expect(Reflect.has(fixture.componentInstance.postsQuery, 'data')).toBe(false);
+
+    await user.click(screen.getByRole('button', { name: 'load posts' }));
+
+    expect(await screen.findByText('lazyQuerySelectedResultContractApi-post')).toBeInTheDocument();
+    expect(Reflect.has(fixture.componentInstance.postsQuery, 'selectedName')).toBe(true);
+    expect(Reflect.has(fixture.componentInstance.postsQuery, 'isLoading')).toBe(false);
+    expect(Reflect.has(fixture.componentInstance.postsQuery, 'data')).toBe(false);
+  });
+
+  test('exposes base lazy query flags as fine-grained signals when selectFromResult returns them', async () => {
+    const { postsApi, resolvePosts } = createDeferredPostsApi('lazyQuerySelectedBaseFlagsApi');
+    const user = userEvent.setup();
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <button (click)="postsQuery()">load posts</button>
+        <p>{{ postsQuery.selectedName() }}</p>
+        <p>{{ postsQuery.isLoading() ? 'loading' : 'not loading' }}</p>
+        <p>{{ postsQuery.isFetching() ? 'fetching' : 'not fetching' }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly postsQuery = postsApi.useLazyGetPostsQuery({
+        selectFromResult: ({ data, isFetching, isLoading }) => ({
+          selectedName: data?.[0]?.name ?? 'empty',
+          isFetching,
+          isLoading,
+        }),
+      });
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(screen.getByText('empty')).toBeInTheDocument();
+    expect(screen.getByText('not loading')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'load posts' }));
+
+    expect(await screen.findByText('loading')).toBeInTheDocument();
+    expect(screen.getByText('fetching')).toBeInTheDocument();
+
+    resolvePosts([{ id: 1, name: 'lazyQuerySelectedBaseFlagsApi-post' }]);
+
+    expect(await screen.findByText('lazyQuerySelectedBaseFlagsApi-post')).toBeInTheDocument();
+    expect(screen.getByText('not loading')).toBeInTheDocument();
+    expect(screen.getByText('not fetching')).toBeInTheDocument();
   });
 
   test('tracks lazy query options from a signal', async () => {

--- a/packages/ngrx-rtk-query/tests/query-hooks.spec.ts
+++ b/packages/ngrx-rtk-query/tests/query-hooks.spec.ts
@@ -6,7 +6,7 @@ import { describe, expect, test } from 'vitest';
 import { skipToken } from 'ngrx-rtk-query/core';
 import { provideNoopStoreApi } from 'ngrx-rtk-query/noop-store';
 
-import { createPostsApi } from './helpers/create-posts-api';
+import { createDeferredPostsApi, createPostsApi } from './helpers/create-posts-api';
 
 describe('query hooks', () => {
   test('loads a query from a static arg', async () => {
@@ -164,6 +164,72 @@ describe('query hooks', () => {
     });
 
     expect(await screen.findByText('querySelectedFunctionPropertyApi-post')).toBeInTheDocument();
+  });
+
+  test('keeps the query signal value limited to the selected query result', async () => {
+    const postsApi = createPostsApi('querySelectedResultContractApi');
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <p>{{ postQuery.selectedName() }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly postQuery = postsApi.useGetPostsQuery(undefined, {
+        selectFromResult: ({ data }) => ({
+          selectedName: data?.[0]?.name ?? 'empty',
+        }),
+      });
+    }
+
+    const { fixture } = await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(await screen.findByText('querySelectedResultContractApi-post')).toBeInTheDocument();
+
+    const result = fixture.componentInstance.postQuery();
+    expect(Reflect.has(result, 'selectedName')).toBe(true);
+    expect(Reflect.has(result, 'isLoading')).toBe(false);
+    expect(Reflect.has(result, 'data')).toBe(false);
+  });
+
+  test('exposes base query flags as fine-grained signals when selectFromResult returns them', async () => {
+    const { postsApi, resolvePosts } = createDeferredPostsApi('querySelectedBaseFlagsApi');
+
+    @Component({
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <p>{{ postQuery.selectedName() }}</p>
+        <p>{{ postQuery.isLoading() ? 'loading' : 'not loading' }}</p>
+        <p>{{ postQuery.isFetching() ? 'fetching' : 'not fetching' }}</p>
+      `,
+    })
+    class HostComponent {
+      readonly postQuery = postsApi.useGetPostsQuery(undefined, {
+        selectFromResult: ({ data, isFetching, isLoading }) => ({
+          selectedName: data?.[0]?.name ?? 'empty',
+          isFetching,
+          isLoading,
+        }),
+      });
+    }
+
+    await render(HostComponent, {
+      providers: [provideNoopStoreApi(postsApi)],
+    });
+
+    expect(await screen.findByText('loading')).toBeInTheDocument();
+    expect(screen.getByText('fetching')).toBeInTheDocument();
+
+    resolvePosts([{ id: 1, name: 'querySelectedBaseFlagsApi-post' }]);
+
+    expect(await screen.findByText('querySelectedBaseFlagsApi-post')).toBeInTheDocument();
+    expect(screen.getByText('not loading')).toBeInTheDocument();
+    expect(screen.getByText('not fetching')).toBeInTheDocument();
   });
 
   test('tracks query options from a signal', async () => {


### PR DESCRIPTION
## Summary

- Document the `selectFromResult` contract for query and lazy query hooks.
- Clarify that selected result keys are exposed as fine-grained signals and base query fields must be returned explicitly.
- Add regression coverage for selected result shape and returned loading/fetching flags.

## Validation

- `pnpm nx test ngrx-rtk-query --skip-nx-cache`
- `pnpm exec nx test ngrx-rtk-query --skip-nx-cache --runInBand --testFile=query-hooks.spec.ts --testFile=lazy-query-hooks.spec.ts`

## Release

No changeset. Documentation/test-only contract coverage.