### PR TITLE
Deprecate root import for store provider

### DIFF
--- a/.changeset/deprecate-root-store-provider.md
+++ b/.changeset/deprecate-root-store-provider.md
@@ -1,0 +1,9 @@
+---
+'ngrx-rtk-query': minor
+---
+
+Deprecate importing `provideStoreApi` from the root entrypoint.
+
+Import `provideStoreApi` from `ngrx-rtk-query/store` instead. Core APIs such as `createApi` and `fetchBaseQuery` remain available from `ngrx-rtk-query`.
+
+This prepares a future major version where the root entrypoint will no longer re-export the NgRx Store provider.

--- a/.changeset/deprecate-root-store-provider.md
+++ b/.changeset/deprecate-root-store-provider.md
@@ -4,6 +4,6 @@
 
 Deprecate importing `provideStoreApi` from the root entrypoint.
 
-Import `provideStoreApi` from `ngrx-rtk-query/store` instead. Core APIs such as `createApi` and `fetchBaseQuery` remain available from `ngrx-rtk-query`.
+Import `provideStoreApi` from `ngrx-rtk-query/store` instead. Core APIs such as `createApi` and `fetchBaseQuery` remain available from `ngrx-rtk-query`. Signal Store runtime features remain available from `ngrx-rtk-query/signal-store`.
 
 This prepares a future major version where the root entrypoint will no longer re-export the NgRx Store provider.

--- a/examples/basic-ngrx-store/src/app/app.config.ts
+++ b/examples/basic-ngrx-store/src/app/app.config.ts
@@ -8,7 +8,8 @@ import {
 } from '@angular/router';
 import { provideStore } from '@ngrx/store';
 import { provideStoreDevtools } from '@ngrx/store-devtools';
-import { provideStoreApi } from 'ngrx-rtk-query';
+
+import { provideStoreApi } from 'ngrx-rtk-query/store';
 
 import { appRoutes } from './app.routes';
 import { postsApi } from './posts/api';

--- a/examples/basic-ngrx-store/src/app/posts/invalidation-without-id.spec.ts
+++ b/examples/basic-ngrx-store/src/app/posts/invalidation-without-id.spec.ts
@@ -3,9 +3,10 @@ import { provideStore } from '@ngrx/store';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { HttpResponse, http } from 'msw';
-import { provideStoreApi } from 'ngrx-rtk-query';
 import { createApi, fetchBaseQuery } from 'ngrx-rtk-query';
 import { describe, expect, test, vi } from 'vitest';
+
+import { provideStoreApi } from 'ngrx-rtk-query/store';
 
 import { server } from '../../mocks/node';
 

--- a/examples/basic-ngrx-store/src/app/posts/posts-list.component.spec.ts
+++ b/examples/basic-ngrx-store/src/app/posts/posts-list.component.spec.ts
@@ -2,8 +2,9 @@ import { provideStore } from '@ngrx/store';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { HttpResponse, http } from 'msw';
-import { provideStoreApi } from 'ngrx-rtk-query';
 import { describe, expect, test } from 'vitest';
+
+import { provideStoreApi } from 'ngrx-rtk-query/store';
 
 import { server } from '../../mocks/node';
 import { postsApi } from './api';

--- a/examples/basic-noop-store/src/app/posts/api.ts
+++ b/examples/basic-noop-store/src/app/posts/api.ts
@@ -1,4 +1,4 @@
-import { createApi, fetchBaseQuery } from 'ngrx-rtk-query';
+import { createApi, fetchBaseQuery } from 'ngrx-rtk-query/core';
 
 import { type Post } from './post.model';
 

--- a/examples/basic-noop-store/src/app/posts/invalidation-without-id.spec.ts
+++ b/examples/basic-noop-store/src/app/posts/invalidation-without-id.spec.ts
@@ -2,9 +2,9 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { HttpResponse, http } from 'msw';
-import { createApi, fetchBaseQuery } from 'ngrx-rtk-query';
 import { describe, expect, test, vi } from 'vitest';
 
+import { createApi, fetchBaseQuery } from 'ngrx-rtk-query/core';
 import { provideNoopStoreApi } from 'ngrx-rtk-query/noop-store';
 
 import { server } from '../../mocks/node';

--- a/packages/ngrx-rtk-query/README.md
+++ b/packages/ngrx-rtk-query/README.md
@@ -72,6 +72,14 @@ Noop Store runtime providers should be imported from the noop-store entrypoint:
 import { provideNoopStoreApi } from 'ngrx-rtk-query/noop-store';
 ```
 
+NgRx Signal Store runtime features should be imported from the signal-store entrypoint:
+
+```ts
+import { withApi, withApiState } from 'ngrx-rtk-query/signal-store';
+```
+
+The signal-store entrypoint requires `@ngrx/signals`.
+
 During the deprecation window, applications that do not install `@ngrx/store` can import core APIs from `ngrx-rtk-query/core` to avoid resolving the deprecated root store provider export.
 
 ## Basic Usage

--- a/packages/ngrx-rtk-query/README.md
+++ b/packages/ngrx-rtk-query/README.md
@@ -14,6 +14,7 @@
 - [Table of Contents](#table-of-contents)
 - [Installation](#installation)
   - [Versions](#versions)
+- [Import paths](#import-paths)
 - [Basic Usage](#basic-usage)
 - [Usage](#usage)
   - [**Queries**](#queries)
@@ -49,6 +50,30 @@ If you use the Signal Store runtime, also install `@ngrx/signals`.
 
 Library majors track Angular majors. Only the latest Angular major in the table above is actively supported, because Angular library compilation is [not compatible across major versions](https://angular.io/guide/creating-libraries#ensuring-library-version-compatibility).
 
+## Import paths
+
+Core APIs such as `createApi` and `fetchBaseQuery` remain available from the root entrypoint:
+
+```ts
+import { createApi, fetchBaseQuery } from 'ngrx-rtk-query';
+```
+
+NgRx Store runtime providers should be imported from the store entrypoint:
+
+```ts
+import { provideStoreApi } from 'ngrx-rtk-query/store';
+```
+
+Importing `provideStoreApi` from `ngrx-rtk-query` is deprecated and will be removed in a future major version.
+
+Noop Store runtime providers should be imported from the noop-store entrypoint:
+
+```ts
+import { provideNoopStoreApi } from 'ngrx-rtk-query/noop-store';
+```
+
+During the deprecation window, applications that do not install `@ngrx/store` can import core APIs from `ngrx-rtk-query/core` to avoid resolving the deprecated root store provider export.
+
 ## Basic Usage
 
 You can follow the official [RTK Query guide with hooks](https://redux-toolkit.js.org/rtk-query/overview), with slight variations.
@@ -57,7 +82,7 @@ You can see the application of this repository for more examples.
 Start by importing createApi and defining an "API slice" that lists the server's base URL and which endpoints we want to interact with:
 
 ```ts
-import { createApi, fetchBaseQuery } from 'ngrx-rtk-query/core';
+import { createApi, fetchBaseQuery } from 'ngrx-rtk-query';
 
 export interface CountResponse {
   count: number;
@@ -99,7 +124,7 @@ export const { useGetCountQuery, useIncrementCountMutation, useDecrementCountMut
 Add the api to one runtime in your `app` or in a `lazy route`.
 
 ```typescript
-import { provideStoreApi } from 'ngrx-rtk-query';
+import { provideStoreApi } from 'ngrx-rtk-query/store';
 import { counterApi } from './route/to/counterApi.ts';
 
 bootstrapApplication(AppComponent, {
@@ -458,7 +483,7 @@ export const postsApi = createApi({
 });
 // ...
 
-import { provideStoreApi } from 'ngrx-rtk-query';
+import { provideStoreApi } from 'ngrx-rtk-query/store';
 
 // ...
   providers: [

--- a/packages/ngrx-rtk-query/index.ts
+++ b/packages/ngrx-rtk-query/index.ts
@@ -1,2 +1,6 @@
+import { provideStoreApi as provideStoreApiFromStore } from 'ngrx-rtk-query/store';
+
 export * from 'ngrx-rtk-query/core';
-export * from 'ngrx-rtk-query/store';
+
+/** @deprecated Import provideStoreApi from 'ngrx-rtk-query/store'. */
+export const provideStoreApi = provideStoreApiFromStore;


### PR DESCRIPTION
## Summary
- deprecates importing `provideStoreApi` from the root entrypoint
- documents `ngrx-rtk-query/store` as the provider import path
- documents `ngrx-rtk-query/signal-store` for Signal Store runtime features
- keeps core APIs such as `createApi` and `fetchBaseQuery` available from `ngrx-rtk-query`
- updates NgRx Store examples to use `ngrx-rtk-query/store` and noop examples to use `ngrx-rtk-query/core`

## Notes
This is a non-breaking migration step. The root entrypoint still exposes `provideStoreApi` for now, but consumers should migrate provider imports to `ngrx-rtk-query/store` before the future major removes the root store provider export.

During this deprecation window, applications that do not install `@ngrx/store` can import core APIs from `ngrx-rtk-query/core` to avoid resolving the deprecated root store provider export. Signal Store runtime features stay under `ngrx-rtk-query/signal-store` and require `@ngrx/signals`.

## Related issue
- #116

## Validation
- `pnpm nx build ngrx-rtk-query --skip-nx-cache`
- confirmed `dist/packages/ngrx-rtk-query/types/ngrx-rtk-query.d.ts` contains the root `@deprecated` marker
- confirmed `dist/packages/ngrx-rtk-query/types/ngrx-rtk-query-store.d.ts` does not deprecate `provideStoreApi`
- `pnpm format:check`
- `pnpm nx run-many -t test -p basic-ngrx-store basic-noop-store --skip-nx-cache --outputStyle=static`