### PR TITLE
refactor: harden runtime host lifecycle

### DIFF
--- a/.changeset/runtime-host-lifecycle.md
+++ b/.changeset/runtime-host-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"ngrx-rtk-query": patch
+---
+
+Refactor runtime host lifecycle mounting behind an internal core helper.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-`ngrx-rtk-query` is an Angular library that adapts RTK Query hooks to Angular signals. Durable maintainer truth lives in `docs/*.md`, `CONTRIBUTING.md`, ADRs, and entrypoint READMEs. Public user documentation lives in `packages/ngrx-rtk-query/README.md`.
+`ngrx-rtk-query` is an Angular 21/Nx 22 library that adapts RTK Query hooks to Angular signals.
 
 ## Project Map
 
@@ -15,20 +15,65 @@
 - `examples/*-e2e` - Playwright runtime tracer bullets.
 - `docs/specs` - active plans and rollout context.
 
-## Durable Docs
+## Owner Docs
 
-- `packages/ngrx-rtk-query/README.md` - public install and usage documentation.
+- `packages/ngrx-rtk-query/README.md` - public install, usage, runtime choice, examples, and troubleshooting.
 - `CONTRIBUTING.md` - contribution flow, change types, evidence, and changesets.
 - `docs/HARNESS.md` - documentation placement and agent harness model.
 - `docs/ARCHITECTURE.md` - entrypoints, runtime hosts, boundaries, and upstream-sync architecture.
-- `docs/TESTING.md` - test strategy, examples, and runtime matrix.
+- `docs/TESTING.md` - test strategy, examples, runtime matrix, and E2E scope.
 - `docs/VALIDATION.md` - validation commands, hooks, and failure recovery.
 - `docs/RELEASE.md` - versioning, changesets, Angular/Nx updates, and RTK Query sync.
 - `docs/adrs/` - accepted durable decisions.
-- `packages/ngrx-rtk-query/core/README.md` - core entrypoint boundary; sibling entrypoint READMEs own runtime-specific details.
+- `packages/ngrx-rtk-query/core/README.md` - core entrypoint boundary.
+- `packages/ngrx-rtk-query/store/README.md`, `packages/ngrx-rtk-query/noop-store/README.md`, and `packages/ngrx-rtk-query/signal-store/README.md` - runtime-specific entrypoint boundaries.
 
-<important if="you need to understand public usage, install paths, examples, or troubleshooting">
-- Read `packages/ngrx-rtk-query/README.md`. It is the canonical public documentation and the root README symlink target.
+<important if="you need to run commands to build, test, lint, validate, serve, publish, or generate code">
+
+Run commands from the repo root with `pnpm`.
+
+| Command                      | Purpose                                                        |
+| ---------------------------- | -------------------------------------------------------------- |
+| `pnpm affected:build`        | Build affected projects.                                       |
+| `pnpm affected:check`        | Run affected lint and typecheck, then format check.            |
+| `pnpm affected:dep-graph`    | Open affected dependency graph.                                |
+| `pnpm affected:e2e`          | Run affected Playwright tracer bullets.                        |
+| `pnpm affected:e2e:watch`    | Run affected Playwright tracer bullets in watch mode.          |
+| `pnpm affected:lint`         | Lint affected projects.                                        |
+| `pnpm affected:test`         | Test affected projects.                                        |
+| `pnpm build:ngrx-rtk-query`  | Build the public package.                                      |
+| `pnpm contributors:add`      | Add an all-contributors entry.                                 |
+| `pnpm contributors:generate` | Regenerate all-contributors output.                            |
+| `pnpm dep-graph`             | Open the full Nx dependency graph.                             |
+| `pnpm dep-graph:watch`       | Open the full Nx dependency graph in watch mode.               |
+| `pnpm dev:basic-store`       | Serve the NgRx Store example.                                  |
+| `pnpm dev:noop-store`        | Serve the Noop Store example.                                  |
+| `pnpm dev:signal-store`      | Serve the Signal Store example.                                |
+| `pnpm docs:check`            | Validate durable documentation structure and links.            |
+| `pnpm format`                | Check formatting.                                              |
+| `pnpm format:check`          | Check formatting.                                              |
+| `pnpm preinstall`            | Enforce pnpm as the package manager.                           |
+| `pnpm prepare`               | Configure Git hooks.                                           |
+| `pnpm pub:beta`              | Build and publish a beta from the package directory.           |
+| `pnpm pub:release`           | Build and publish a stable release from the package directory. |
+| `pnpm release`               | Version packages with Changesets.                              |
+| `pnpm update`                | Run Nx migrations.                                             |
+| `pnpm verify`                | Default affected lint, typecheck, and conditional docs check.  |
+| `pnpm verify:branch`         | Default branch-scoped verification against `origin/main`.      |
+| `pnpm verify:branch:full`    | Full branch-scoped verification used by pre-push.              |
+| `pnpm verify:full`           | Full local verification with tests and format check.           |
+
+</important>
+
+<important if="you need public usage, install paths, runtime choice, examples, or troubleshooting">
+- Read `packages/ngrx-rtk-query/README.md`; the root `README.md` is a symlink to it.
+</important>
+
+<important if="you are changing documentation, harness files, scripts, hooks, package metadata, or release configuration">
+- Read `docs/HARNESS.md`, `docs/VALIDATION.md`, and `docs/RELEASE.md`.
+- Keep durable docs free of active rollout notes; use `docs/specs/` for plans.
+- Run `pnpm docs:check` for focused documentation validation.
+- Agent stop hooks are configured in `.codex/hooks.json`, `.claude/settings.json`, and `.opencode/plugins/verify-on-idle.ts`.
 </important>
 
 <important if="you are choosing where code lives, changing public exports, or touching runtime boundaries">
@@ -40,19 +85,12 @@
 <important if="you are fixing behavior, changing hooks, changing lifecycle, or adding tests">
 - Prefer a failing public-surface test before implementation when practical.
 - Test through published entrypoints and generated APIs, not private helpers.
-- Check the runtime matrix in `docs/TESTING.md` for host-specific regressions.
-</important>
-
-<important if="you are changing docs, harness files, scripts, hooks, release config, or package metadata">
-- Read `docs/HARNESS.md`, `docs/VALIDATION.md`, and `docs/RELEASE.md`.
-- Keep durable docs free of active rollout notes. Use `docs/specs/` for plans.
-- Run `pnpm docs:check` for focused documentation validation.
-- Agent stop hooks are configured in `.codex/hooks.json`, `.claude/settings.json`, and `.opencode/plugins/verify-on-idle.ts`.
+- Check `docs/TESTING.md` for the runtime matrix and host-specific regressions.
 </important>
 
 <important if="you are validating changes or preparing a handoff">
 - Use `pnpm verify` as the default local validation command.
-- Use `pnpm verify:full` for behavior, public contract, runtime lifecycle, example, dependency, or release changes.
+- Use `pnpm verify:full` for behavior, public contract, runtime lifecycle, example, dependency, configuration, or release changes.
 - Add `pnpm build:ngrx-rtk-query` when the published package surface changed.
 </important>
 
@@ -73,7 +111,7 @@
 
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->
-<important if="you are working with Nx (scaffolding, running tasks, or exploring projects)">
+<important if="you are working with Nx scaffolding, Nx tasks, affected projects, or project graph exploration">
 - Use `pnpm nx run`, `pnpm nx run-many`, and `pnpm nx affected` instead of underlying tools.
 - Explore projects with `pnpm nx show projects` and `pnpm nx show project <project> --json`.
 - Read `docs/VALIDATION.md` before changing task or verification behavior.

--- a/packages/ngrx-rtk-query/core/index.ts
+++ b/packages/ngrx-rtk-query/core/index.ts
@@ -4,6 +4,7 @@ export { setupRuntimeListeners } from './src/setup-runtime-listeners';
 
 export { UNINITIALIZED_VALUE } from './src/constants';
 export { createApi } from './src/create-api';
+export { ɵinternalMountRuntimeApi, type ɵInternalRuntimeMountApi } from './src/runtime-mount';
 export { shallowEqual } from './src/utils';
 export type { DeepSignal, Signal, SignalsMap } from './src/utils';
 

--- a/packages/ngrx-rtk-query/core/src/create-api.ts
+++ b/packages/ngrx-rtk-query/core/src/create-api.ts
@@ -17,7 +17,6 @@ import {
 } from './module';
 
 type ApiBindingMetadata = {
-  bindingKey: object;
   runtimeLabel: string;
 };
 
@@ -106,11 +105,10 @@ export const createApi: CreateApi<typeof coreModuleName | typeof angularHooksMod
   const initApiStore = (
     setupFn: () => AngularHooksModuleOptions,
     nextBindingMetadata: ApiBindingMetadata = {
-      bindingKey: {},
       runtimeLabel: 'unknown',
     },
   ) => {
-    if (activeBinding && activeBinding.bindingKey !== nextBindingMetadata.bindingKey) {
+    if (activeBinding) {
       throw new Error(
         `RTK Query api instance for reducerPath "${resolvedReducerPath}" is already bound to another host (${activeBinding.runtimeLabel}). Reuse one host per api instance or create a second api instance.`,
       );
@@ -120,7 +118,7 @@ export const createApi: CreateApi<typeof coreModuleName | typeof angularHooksMod
     activeBinding = binding;
 
     return () => {
-      if (activeBinding?.bindingKey === nextBindingMetadata.bindingKey) {
+      if (activeBinding === binding) {
         activeBinding = undefined;
       }
     };

--- a/packages/ngrx-rtk-query/core/src/runtime-mount.ts
+++ b/packages/ngrx-rtk-query/core/src/runtime-mount.ts
@@ -10,7 +10,6 @@ export type ɵInternalRuntimeMountApi = {
   initApiStore: (
     setupFn: () => AngularHooksModuleOptions,
     bindingMetadata: {
-      bindingKey: object;
       runtimeLabel: string;
     },
   ) => () => void;
@@ -23,7 +22,6 @@ export type ɵInternalRuntimeMountApi = {
 export type ɵInternalRuntimeMountOptions = {
   api: ɵInternalRuntimeMountApi;
   setupFn: () => AngularHooksModuleOptions;
-  bindingKey: object;
   runtimeLabel: string;
   setupListeners?: StoreQueryConfig['setupListeners'];
 };
@@ -31,15 +29,15 @@ export type ɵInternalRuntimeMountOptions = {
 export function ɵinternalMountRuntimeApi({
   api,
   setupFn,
-  bindingKey,
   runtimeLabel,
   setupListeners,
 }: ɵInternalRuntimeMountOptions): () => void {
   let releaseApiStore: (() => void) | undefined;
   let teardownListeners: (() => void) | undefined;
+  let released = false;
 
   try {
-    releaseApiStore = api.initApiStore(setupFn, { bindingKey, runtimeLabel });
+    releaseApiStore = api.initApiStore(setupFn, { runtimeLabel });
     teardownListeners = setupRuntimeListeners(api.dispatch, setupListeners);
   } catch (error) {
     teardownListeners?.();
@@ -49,6 +47,11 @@ export function ɵinternalMountRuntimeApi({
   }
 
   return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+
     let cleanupError: unknown;
     let hasCleanupError = false;
     const runCleanup = (cleanup: (() => void) | undefined) => {

--- a/packages/ngrx-rtk-query/core/src/runtime-mount.ts
+++ b/packages/ngrx-rtk-query/core/src/runtime-mount.ts
@@ -1,0 +1,75 @@
+import { type UnknownAction } from '@reduxjs/toolkit';
+
+import { type AngularHooksModuleOptions, type Dispatch } from './module';
+import { setupRuntimeListeners } from './setup-runtime-listeners';
+import { type StoreQueryConfig } from './types';
+
+/** @internal */
+export type ɵInternalRuntimeMountApi = {
+  dispatch: Dispatch;
+  initApiStore: (
+    setupFn: () => AngularHooksModuleOptions,
+    bindingMetadata: {
+      bindingKey: object;
+      runtimeLabel: string;
+    },
+  ) => () => void;
+  util: {
+    resetApiState: () => UnknownAction;
+  };
+};
+
+/** @internal */
+export type ɵInternalRuntimeMountOptions = {
+  api: ɵInternalRuntimeMountApi;
+  setupFn: () => AngularHooksModuleOptions;
+  bindingKey: object;
+  runtimeLabel: string;
+  setupListeners?: StoreQueryConfig['setupListeners'];
+};
+
+export function ɵinternalMountRuntimeApi({
+  api,
+  setupFn,
+  bindingKey,
+  runtimeLabel,
+  setupListeners,
+}: ɵInternalRuntimeMountOptions): () => void {
+  let releaseApiStore: (() => void) | undefined;
+  let teardownListeners: (() => void) | undefined;
+
+  try {
+    releaseApiStore = api.initApiStore(setupFn, { bindingKey, runtimeLabel });
+    teardownListeners = setupRuntimeListeners(api.dispatch, setupListeners);
+  } catch (error) {
+    teardownListeners?.();
+    releaseApiStore?.();
+
+    throw error;
+  }
+
+  return () => {
+    let cleanupError: unknown;
+    let hasCleanupError = false;
+    const runCleanup = (cleanup: (() => void) | undefined) => {
+      try {
+        cleanup?.();
+      } catch (error) {
+        if (!hasCleanupError) {
+          cleanupError = error;
+          hasCleanupError = true;
+        }
+      }
+    };
+
+    runCleanup(teardownListeners);
+    runCleanup(() => {
+      api.dispatch(api.util.resetApiState());
+    });
+    runCleanup(releaseApiStore);
+
+    if (hasCleanupError) {
+      throw cleanupError;
+    }
+  };
+}

--- a/packages/ngrx-rtk-query/ng-package.json
+++ b/packages/ngrx-rtk-query/ng-package.json
@@ -1,6 +1,7 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/packages/ngrx-rtk-query",
+  "assets": ["logo.svg"],
   "lib": {
     "entryFile": "index.ts"
   }

--- a/packages/ngrx-rtk-query/noop-store/src/provide-noop-store-api.ts
+++ b/packages/ngrx-rtk-query/noop-store/src/provide-noop-store-api.ts
@@ -18,7 +18,8 @@ import {
   type AngularHooksModuleOptions,
   type Dispatch,
   type StoreQueryConfig,
-  setupRuntimeListeners,
+  type ɵInternalRuntimeMountApi,
+  ɵinternalMountRuntimeApi,
 } from 'ngrx-rtk-query/core';
 
 @Injectable()
@@ -50,8 +51,10 @@ const createNoopStoreApi = (
     const reducerPath = api.reducerPath;
     const reducer = api.reducer as Reducer<any>;
 
-    // Initialize the store with the initial state
-    store.state.update((state) => ({ ...state, [reducerPath]: {} }));
+    const initialState = reducer(undefined, {
+      type: '@@ngrx-rtk-query/noop-store/init',
+    });
+    store.state.update((state) => ({ ...state, [reducerPath]: initialState }));
 
     const dispatch = (action: UnknownAction) => {
       store.dispatch(action, { reducerPath, reducer });
@@ -83,29 +86,17 @@ export function provideNoopStoreApi(
       multi: true,
       useValue() {
         const destroyRef = inject(DestroyRef);
-        const bindingMetadata = {
-          bindingKey: {},
+        const bindingKey = {};
+        const releaseRuntime = ɵinternalMountRuntimeApi({
+          api: api as unknown as ɵInternalRuntimeMountApi,
+          setupFn: createNoopStoreApi(api),
+          bindingKey,
           runtimeLabel: 'noop-store',
-        };
-        let releaseApiStore: (() => void) | undefined;
-        let teardownListeners: (() => void) | undefined;
-
-        try {
-          releaseApiStore = api.initApiStore(createNoopStoreApi(api), bindingMetadata);
-          teardownListeners = setupRuntimeListeners(api.dispatch as Dispatch, setupListeners);
-
-          api.dispatch(api.util.resetApiState());
-        } catch (error) {
-          teardownListeners?.();
-          releaseApiStore?.();
-
-          throw error;
-        }
+          setupListeners,
+        });
 
         destroyRef.onDestroy(() => {
-          teardownListeners?.();
-          api.dispatch(api.util.resetApiState());
-          releaseApiStore?.();
+          releaseRuntime();
         });
       },
     },

--- a/packages/ngrx-rtk-query/noop-store/src/provide-noop-store-api.ts
+++ b/packages/ngrx-rtk-query/noop-store/src/provide-noop-store-api.ts
@@ -1,7 +1,6 @@
 import {
   type CreateComputedOptions,
   DestroyRef,
-  ENVIRONMENT_INITIALIZER,
   type EnvironmentProviders,
   Injectable,
   Injector,
@@ -9,6 +8,7 @@ import {
   computed,
   inject,
   makeEnvironmentProviders,
+  provideEnvironmentInitializer,
   signal,
 } from '@angular/core';
 import { type Reducer, type Selector, type UnknownAction } from '@reduxjs/toolkit';
@@ -81,24 +81,18 @@ export function provideNoopStoreApi(
 ): EnvironmentProviders {
   return makeEnvironmentProviders([
     ApiStore,
-    {
-      provide: ENVIRONMENT_INITIALIZER,
-      multi: true,
-      useValue() {
-        const destroyRef = inject(DestroyRef);
-        const bindingKey = {};
-        const releaseRuntime = ɵinternalMountRuntimeApi({
-          api: api as unknown as ɵInternalRuntimeMountApi,
-          setupFn: createNoopStoreApi(api),
-          bindingKey,
-          runtimeLabel: 'noop-store',
-          setupListeners,
-        });
+    provideEnvironmentInitializer(() => {
+      const destroyRef = inject(DestroyRef);
+      const releaseRuntime = ɵinternalMountRuntimeApi({
+        api: api as unknown as ɵInternalRuntimeMountApi,
+        setupFn: createNoopStoreApi(api),
+        runtimeLabel: 'noop-store',
+        setupListeners,
+      });
 
-        destroyRef.onDestroy(() => {
-          releaseRuntime();
-        });
-      },
-    },
+      destroyRef.onDestroy(() => {
+        releaseRuntime();
+      });
+    }),
   ]);
 }

--- a/packages/ngrx-rtk-query/signal-store/src/with-api.ts
+++ b/packages/ngrx-rtk-query/signal-store/src/with-api.ts
@@ -174,7 +174,6 @@ export function withApi<TApi extends RuntimeApi<any>>(
     withHooks((store) => {
       const injector = inject(Injector);
       const unregisterApi = registerMountedApi(store as unknown as StoreMembersWithMountedApiRegistry, initializedApi);
-      const bindingKey = {};
       const state = signal(initialState);
       let releaseRuntime: (() => void) | undefined;
       const entry: RegisteredApi = {
@@ -191,7 +190,6 @@ export function withApi<TApi extends RuntimeApi<any>>(
             releaseRuntime = ɵinternalMountRuntimeApi({
               api: initializedApi,
               setupFn: createSignalStoreApi(entry),
-              bindingKey,
               runtimeLabel: 'signal-store',
               setupListeners,
             });

--- a/packages/ngrx-rtk-query/signal-store/src/with-api.ts
+++ b/packages/ngrx-rtk-query/signal-store/src/with-api.ts
@@ -14,7 +14,8 @@ import {
   type Dispatch,
   type SelectSignalOptions,
   type StoreQueryConfig,
-  setupRuntimeListeners,
+  type ɵInternalRuntimeMountApi,
+  ɵinternalMountRuntimeApi,
 } from 'ngrx-rtk-query/core';
 
 type RuntimeApi<Definitions extends EndpointDefinitions = Record<string, any>> = Api<
@@ -25,21 +26,11 @@ type RuntimeApi<Definitions extends EndpointDefinitions = Record<string, any>> =
   any
 >;
 
-type InitializedRuntimeApi<Definitions extends EndpointDefinitions = Record<string, any>> = RuntimeApi<Definitions> & {
-  dispatch: Dispatch;
-  initApiStore: (
-    setupFn: () => AngularHooksModuleOptions,
-    bindingMetadata: {
-      bindingKey: object;
-      runtimeLabel: string;
-    },
-  ) => () => void;
-  reducer: (state: unknown, action: UnknownAction) => unknown;
-  reducerPath: string;
-  util: {
-    resetApiState: () => UnknownAction;
+type InitializedRuntimeApi<Definitions extends EndpointDefinitions = Record<string, any>> = RuntimeApi<Definitions> &
+  ɵInternalRuntimeMountApi & {
+    reducer: (state: unknown, action: UnknownAction) => unknown;
+    reducerPath: string;
   };
-};
 
 type RegisteredApi = {
   api: InitializedRuntimeApi;
@@ -185,8 +176,7 @@ export function withApi<TApi extends RuntimeApi<any>>(
       const unregisterApi = registerMountedApi(store as unknown as StoreMembersWithMountedApiRegistry, initializedApi);
       const bindingKey = {};
       const state = signal(initialState);
-      let releaseApiStore: (() => void) | undefined;
-      let teardownListeners: (() => void) | undefined;
+      let releaseRuntime: (() => void) | undefined;
       const entry: RegisteredApi = {
         api: initializedApi,
         injector,
@@ -198,24 +188,21 @@ export function withApi<TApi extends RuntimeApi<any>>(
       return {
         onInit: () => {
           try {
-            releaseApiStore = initializedApi.initApiStore(createSignalStoreApi(entry), {
+            releaseRuntime = ɵinternalMountRuntimeApi({
+              api: initializedApi,
+              setupFn: createSignalStoreApi(entry),
               bindingKey,
               runtimeLabel: 'signal-store',
+              setupListeners,
             });
-            initializedApi.dispatch(initializedApi.util.resetApiState());
-            teardownListeners = setupRuntimeListeners(initializedApi.dispatch, setupListeners);
           } catch (error) {
-            teardownListeners?.();
-            releaseApiStore?.();
             unregisterApi();
 
             throw error;
           }
         },
         onDestroy: () => {
-          teardownListeners?.();
-          initializedApi.dispatch(initializedApi.util.resetApiState());
-          releaseApiStore?.();
+          releaseRuntime?.();
           unregisterApi();
         },
       };

--- a/packages/ngrx-rtk-query/store/src/provide-store-api.ts
+++ b/packages/ngrx-rtk-query/store/src/provide-store-api.ts
@@ -1,11 +1,11 @@
 import {
   DestroyRef,
-  ENVIRONMENT_INITIALIZER,
   type EnvironmentProviders,
   Injector,
   type Signal,
   inject,
   makeEnvironmentProviders,
+  provideEnvironmentInitializer,
 } from '@angular/core';
 import { type Action, Store, createSelectorFactory, defaultMemoize, provideState } from '@ngrx/store';
 import { type Api } from '@reduxjs/toolkit/query';
@@ -51,25 +51,19 @@ export function provideStoreApi(
   { setupListeners }: StoreQueryConfig = {},
 ): EnvironmentProviders {
   return makeEnvironmentProviders([
-    {
-      provide: ENVIRONMENT_INITIALIZER,
-      multi: true,
-      useValue() {
-        const destroyRef = inject(DestroyRef);
-        const bindingKey = {};
-        const releaseRuntime = ɵinternalMountRuntimeApi({
-          api: api as unknown as ɵInternalRuntimeMountApi,
-          setupFn: createStoreApi(api),
-          bindingKey,
-          runtimeLabel: 'store',
-          setupListeners,
-        });
+    provideEnvironmentInitializer(() => {
+      const destroyRef = inject(DestroyRef);
+      const releaseRuntime = ɵinternalMountRuntimeApi({
+        api: api as unknown as ɵInternalRuntimeMountApi,
+        setupFn: createStoreApi(api),
+        runtimeLabel: 'store',
+        setupListeners,
+      });
 
-        destroyRef.onDestroy(() => {
-          releaseRuntime();
-        });
-      },
-    },
+      destroyRef.onDestroy(() => {
+        releaseRuntime();
+      });
+    }),
     provideState(api.reducerPath, api.reducer),
   ]);
 }

--- a/packages/ngrx-rtk-query/store/src/provide-store-api.ts
+++ b/packages/ngrx-rtk-query/store/src/provide-store-api.ts
@@ -15,8 +15,9 @@ import {
   type Dispatch,
   type SelectSignalOptions,
   type StoreQueryConfig,
-  setupRuntimeListeners,
   shallowEqual,
+  type ɵInternalRuntimeMountApi,
+  ɵinternalMountRuntimeApi,
 } from 'ngrx-rtk-query/core';
 
 const createStoreApi = (
@@ -55,27 +56,17 @@ export function provideStoreApi(
       multi: true,
       useValue() {
         const destroyRef = inject(DestroyRef);
-        const bindingMetadata = {
-          bindingKey: {},
+        const bindingKey = {};
+        const releaseRuntime = ɵinternalMountRuntimeApi({
+          api: api as unknown as ɵInternalRuntimeMountApi,
+          setupFn: createStoreApi(api),
+          bindingKey,
           runtimeLabel: 'store',
-        };
-        let releaseApiStore: (() => void) | undefined;
-        let teardownListeners: (() => void) | undefined;
-
-        try {
-          releaseApiStore = api.initApiStore(createStoreApi(api), bindingMetadata);
-          teardownListeners = setupRuntimeListeners(api.dispatch as Dispatch, setupListeners);
-        } catch (error) {
-          teardownListeners?.();
-          releaseApiStore?.();
-
-          throw error;
-        }
+          setupListeners,
+        });
 
         destroyRef.onDestroy(() => {
-          teardownListeners?.();
-          api.dispatch(api.util.resetApiState());
-          releaseApiStore?.();
+          releaseRuntime();
         });
       },
     },

--- a/packages/ngrx-rtk-query/tests/create-api.spec.ts
+++ b/packages/ngrx-rtk-query/tests/create-api.spec.ts
@@ -1,16 +1,21 @@
 import { type UnknownAction } from '@reduxjs/toolkit';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
-import { type AngularHooksModuleOptions, type Dispatch } from 'ngrx-rtk-query/core';
+import {
+  type AngularHooksModuleOptions,
+  type Dispatch,
+  type ɵInternalRuntimeMountApi,
+  ɵinternalMountRuntimeApi,
+} from 'ngrx-rtk-query/core';
 
 import { createPostsApi } from './helpers/create-posts-api';
+import { recordRuntimeLifecycle } from './helpers/record-runtime-lifecycle';
 
 type InitializedTestApi = ReturnType<typeof createPostsApi> & {
   dispatch: Dispatch;
   initApiStore: (
     setupFn: () => AngularHooksModuleOptions,
     bindingMetadata: {
-      bindingKey: object;
       runtimeLabel: string;
     },
   ) => () => void;
@@ -20,31 +25,31 @@ const unusedUseSelector = (() => {
   throw new Error('useSelector should not be called in create-api tests');
 }) as AngularHooksModuleOptions['hooks']['useSelector'];
 
-const initBoundTestApiStore = (postsApi: InitializedTestApi) => {
+const createTestStoreSetup = (postsApi: InitializedTestApi) => {
   let currentState = postsApi.reducer(undefined, {
     type: '@@ngrx-rtk-query/test/init',
   });
 
-  return {
-    releaseApiStore: postsApi.initApiStore(
-      () =>
-        ({
-          hooks: {
-            dispatch: ((action: UnknownAction) => {
-              currentState = postsApi.reducer(currentState, action);
-              return action;
-            }) as Dispatch,
-            getState: () => ({ [postsApi.reducerPath]: currentState }),
-            useSelector: unusedUseSelector,
-          },
-          createSelector: () => (() => undefined) as never,
-          getInjector: () => ({}) as never,
-        }) satisfies AngularHooksModuleOptions,
-      {
-        bindingKey: {},
-        runtimeLabel: 'create-api-test',
+  return () =>
+    ({
+      hooks: {
+        dispatch: ((action: UnknownAction) => {
+          currentState = postsApi.reducer(currentState, action);
+          return action;
+        }) as Dispatch,
+        getState: () => ({ [postsApi.reducerPath]: currentState }),
+        useSelector: unusedUseSelector,
       },
-    ),
+      createSelector: () => (() => undefined) as never,
+      getInjector: () => ({}) as never,
+    }) satisfies AngularHooksModuleOptions;
+};
+
+const initBoundTestApiStore = (postsApi: InitializedTestApi) => {
+  return {
+    releaseApiStore: postsApi.initApiStore(createTestStoreSetup(postsApi), {
+      runtimeLabel: 'create-api-test',
+    }),
   };
 };
 
@@ -91,5 +96,42 @@ describe('createApi', () => {
     expect(() => postsApi.dispatch({ type: 'releasedTimerApi/customAction' })).toThrow(
       /Provide the API \(releasedTimerApi\) is necessary to use the queries/,
     );
+  });
+
+  test('does not let a stale release clear a newer binding', () => {
+    const postsApi = createPostsApi('staleReleaseApi') as InitializedTestApi;
+    const releaseFirst = postsApi.initApiStore(createTestStoreSetup(postsApi), {
+      runtimeLabel: 'first-test-host',
+    });
+    releaseFirst();
+    const releaseSecond = postsApi.initApiStore(createTestStoreSetup(postsApi), {
+      runtimeLabel: 'second-test-host',
+    });
+
+    releaseFirst();
+
+    expect(() => postsApi.dispatch({ type: 'staleReleaseApi/customAction' })).not.toThrow();
+
+    releaseSecond();
+
+    expect(() => postsApi.dispatch({ type: 'staleReleaseApi/customAction' })).toThrow(
+      /Provide the API \(staleReleaseApi\) is necessary to use the queries/,
+    );
+  });
+
+  test('does not reset again when runtime release is called more than once', () => {
+    const postsApi = createPostsApi('idempotentRuntimeReleaseApi') as InitializedTestApi & ɵInternalRuntimeMountApi;
+    const { events, setupListeners } = recordRuntimeLifecycle(postsApi);
+    const releaseRuntime = ɵinternalMountRuntimeApi({
+      api: postsApi,
+      setupFn: createTestStoreSetup(postsApi),
+      runtimeLabel: 'create-api-test',
+      setupListeners,
+    });
+
+    releaseRuntime();
+    releaseRuntime();
+
+    expect(events).toEqual(['listeners', 'teardown', 'reset']);
   });
 });

--- a/packages/ngrx-rtk-query/tests/helpers/record-runtime-lifecycle.ts
+++ b/packages/ngrx-rtk-query/tests/helpers/record-runtime-lifecycle.ts
@@ -1,0 +1,31 @@
+import { vi } from 'vitest';
+
+type RuntimeLifecycleApi = {
+  dispatch: (action: unknown) => unknown;
+  util: {
+    resetApiState: {
+      match: (action: unknown) => boolean;
+    };
+  };
+};
+
+export const recordRuntimeLifecycle = (api: RuntimeLifecycleApi) => {
+  const events: string[] = [];
+  const dispatch = api.dispatch;
+  vi.spyOn(api, 'dispatch').mockImplementation((action) => {
+    if (api.util.resetApiState.match(action)) {
+      events.push('reset');
+    }
+
+    return dispatch(action);
+  });
+  const setupListeners = vi.fn(() => {
+    events.push('listeners');
+
+    return () => {
+      events.push('teardown');
+    };
+  });
+
+  return { events, setupListeners };
+};

--- a/packages/ngrx-rtk-query/tests/noop-store/provide-noop-store-api.spec.ts
+++ b/packages/ngrx-rtk-query/tests/noop-store/provide-noop-store-api.spec.ts
@@ -7,6 +7,7 @@ import { ApiStore } from 'ngrx-rtk-query/noop-store';
 import { provideNoopStoreApi } from 'ngrx-rtk-query/noop-store';
 
 import { createPostsApi } from '../helpers/create-posts-api';
+import { recordRuntimeLifecycle } from '../helpers/record-runtime-lifecycle';
 
 describe('provideNoopStoreApi', () => {
   test('allocates a distinct binding key per environment injector when providers are reused', () => {
@@ -103,5 +104,21 @@ describe('provideNoopStoreApi', () => {
     });
 
     expect(screen.getByTestId('selected-status')).toHaveTextContent('uninitialized');
+  });
+
+  test('resets api state only on destroy', () => {
+    const postsApi = createPostsApi('noopResetTimingApi');
+    const { events, setupListeners } = recordRuntimeLifecycle(postsApi);
+
+    TestBed.configureTestingModule({});
+    const parent = TestBed.inject(EnvironmentInjector);
+    const environment = createEnvironmentInjector([provideNoopStoreApi(postsApi, { setupListeners })], parent);
+
+    expect(setupListeners).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(['listeners']);
+
+    environment.destroy();
+
+    expect(events).toEqual(['listeners', 'teardown', 'reset']);
   });
 });

--- a/packages/ngrx-rtk-query/tests/noop-store/provide-noop-store-api.spec.ts
+++ b/packages/ngrx-rtk-query/tests/noop-store/provide-noop-store-api.spec.ts
@@ -10,7 +10,7 @@ import { createPostsApi } from '../helpers/create-posts-api';
 import { recordRuntimeLifecycle } from '../helpers/record-runtime-lifecycle';
 
 describe('provideNoopStoreApi', () => {
-  test('allocates a distinct binding key per environment injector when providers are reused', () => {
+  test('rejects concurrent host reuse and allows reuse after destroy', () => {
     const postsApi = createPostsApi('noopSharedProvidersApi');
     const providers = [provideNoopStoreApi(postsApi)];
 

--- a/packages/ngrx-rtk-query/tests/signal-store/with-api.spec.ts
+++ b/packages/ngrx-rtk-query/tests/signal-store/with-api.spec.ts
@@ -14,6 +14,7 @@ import { createApi, fakeBaseQuery } from 'ngrx-rtk-query/core';
 import { withApi } from 'ngrx-rtk-query/signal-store';
 
 import { type Post, createPostsApi } from '../helpers/create-posts-api';
+import { recordRuntimeLifecycle } from '../helpers/record-runtime-lifecycle';
 
 describe('withApi', () => {
   test('mounts an api and keeps hooks working', async () => {
@@ -227,5 +228,22 @@ describe('withApi', () => {
     await waitFor(() => {
       expect(screen.getByTestId('query-name')).toHaveTextContent('recoverySignalStoreApi-post');
     });
+  });
+
+  test('resets api state only on destroy', () => {
+    const postsApi = createPostsApi('signalStoreResetTimingApi');
+    const { events, setupListeners } = recordRuntimeLifecycle(postsApi);
+    const SignalStoreRuntime = signalStore(withApi(postsApi, { setupListeners }));
+
+    const parent = TestBed.inject(EnvironmentInjector);
+    const environment = createEnvironmentInjector([SignalStoreRuntime], parent);
+    environment.get(SignalStoreRuntime);
+
+    expect(setupListeners).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(['listeners']);
+
+    environment.destroy();
+
+    expect(events).toEqual(['listeners', 'teardown', 'reset']);
   });
 });

--- a/packages/ngrx-rtk-query/tests/store/provide-store-api.spec.ts
+++ b/packages/ngrx-rtk-query/tests/store/provide-store-api.spec.ts
@@ -7,6 +7,7 @@ import { describe, expect, test, vi } from 'vitest';
 import { provideStoreApi } from 'ngrx-rtk-query/store';
 
 import { createPostsApi } from '../helpers/create-posts-api';
+import { recordRuntimeLifecycle } from '../helpers/record-runtime-lifecycle';
 
 describe('provideStoreApi', () => {
   test('allocates a distinct binding key per environment injector when providers are reused', () => {
@@ -89,5 +90,47 @@ describe('provideStoreApi', () => {
     });
 
     expect(screen.getByTestId('selected-status')).toHaveTextContent('uninitialized');
+  });
+
+  test('resets api state only on destroy', () => {
+    const postsApi = createPostsApi('storeResetTimingApi');
+    const { events, setupListeners } = recordRuntimeLifecycle(postsApi);
+
+    TestBed.configureTestingModule({});
+    const parent = TestBed.inject(EnvironmentInjector);
+    const environment = createEnvironmentInjector(
+      [provideStore(), provideStoreApi(postsApi, { setupListeners })],
+      parent,
+    );
+
+    expect(setupListeners).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(['listeners']);
+
+    environment.destroy();
+
+    expect(events).toEqual(['listeners', 'teardown', 'reset']);
+  });
+
+  test('releases api binding when destroy reset fails', () => {
+    const postsApi = createPostsApi('storeResetFailureApi');
+    const resetApiState = postsApi.util.resetApiState;
+    const dispatch = postsApi.dispatch;
+    const dispatchSpy = vi.spyOn(postsApi, 'dispatch').mockImplementation((action) => {
+      if (resetApiState.match(action)) {
+        throw new Error('reset failed');
+      }
+
+      return dispatch(action);
+    });
+
+    TestBed.configureTestingModule({});
+    const parent = TestBed.inject(EnvironmentInjector);
+    const firstEnvironment = createEnvironmentInjector([provideStore(), provideStoreApi(postsApi)], parent);
+
+    expect(() => firstEnvironment.destroy()).toThrow(/reset failed/);
+
+    dispatchSpy.mockImplementation((action) => dispatch(action));
+    const secondEnvironment = createEnvironmentInjector([provideStore(), provideStoreApi(postsApi)], parent);
+    secondEnvironment.destroy();
   });
 });

--- a/packages/ngrx-rtk-query/tests/store/provide-store-api.spec.ts
+++ b/packages/ngrx-rtk-query/tests/store/provide-store-api.spec.ts
@@ -10,7 +10,7 @@ import { createPostsApi } from '../helpers/create-posts-api';
 import { recordRuntimeLifecycle } from '../helpers/record-runtime-lifecycle';
 
 describe('provideStoreApi', () => {
-  test('allocates a distinct binding key per environment injector when providers are reused', () => {
+  test('rejects concurrent host reuse and allows reuse after destroy', () => {
     const postsApi = createPostsApi('storeSharedProvidersApi');
     const providers = [provideStore(), provideStoreApi(postsApi)];
 


### PR DESCRIPTION
## Summary

- Refactor runtime host lifecycle mounting behind an internal core helper.
- Remove the external binding key contract and make release use the created binding identity.
- Replace deprecated `ENVIRONMENT_INITIALIZER` usage with `provideEnvironmentInitializer`.
- Add lifecycle regression coverage for reset timing, stale release handling, and idempotent runtime release.
- Include a patch changeset for the package refactor.

## Validation

- Pre-push `pnpm verify:branch:full --base=origin/main --head=HEAD` passed via the repository hook.
- Earlier focused checks passed for package tests, build, lint, formatting, docs check, and diff whitespace.
